### PR TITLE
Add linkdep helpers for IO and keyboard

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -8,7 +8,9 @@
 - Kernel initializes memory manager on boot
 - Memory usage per app can be tracked and limited
 - Pointer-sized heap pointers remove compiler warnings
+- Static `io` helpers simplify port I/O access
 
 ## New Features
 - Example `memtest` module using new API
 - Host test script `tests/test_mem.sh` verifying allocator
+- PS/2 keyboard module and updated `console_getc`

--- a/include/io.h
+++ b/include/io.h
@@ -1,0 +1,9 @@
+#ifndef IO_H
+#define IO_H
+#include <stdint.h>
+
+void io_outb(uint16_t port, uint8_t val);
+uint8_t io_inb(uint16_t port);
+void io_wait(void);
+
+#endif /* IO_H */

--- a/include/ps2kbd.h
+++ b/include/ps2kbd.h
@@ -1,0 +1,7 @@
+#ifndef PS2KBD_H
+#define PS2KBD_H
+#include <stdint.h>
+
+uint8_t ps2kbd_read_scancode(void);
+
+#endif /* PS2KBD_H */

--- a/linkdep/console_getc.c
+++ b/linkdep/console_getc.c
@@ -1,5 +1,58 @@
-// auto-generated stub for console_getc
+#include <stdint.h>
 #include "console.h"
+#include "ps2kbd.h"
+
+static char scancode_to_ascii(uint8_t sc) {
+    switch(sc) {
+        case 0x02: return '1';
+        case 0x03: return '2';
+        case 0x04: return '3';
+        case 0x05: return '4';
+        case 0x06: return '5';
+        case 0x07: return '6';
+        case 0x08: return '7';
+        case 0x09: return '8';
+        case 0x0A: return '9';
+        case 0x0B: return '0';
+        case 0x10: return 'q';
+        case 0x11: return 'w';
+        case 0x12: return 'e';
+        case 0x13: return 'r';
+        case 0x14: return 't';
+        case 0x15: return 'y';
+        case 0x16: return 'u';
+        case 0x17: return 'i';
+        case 0x18: return 'o';
+        case 0x19: return 'p';
+        case 0x1E: return 'a';
+        case 0x1F: return 's';
+        case 0x20: return 'd';
+        case 0x21: return 'f';
+        case 0x22: return 'g';
+        case 0x23: return 'h';
+        case 0x24: return 'j';
+        case 0x25: return 'k';
+        case 0x26: return 'l';
+        case 0x2C: return 'z';
+        case 0x2D: return 'x';
+        case 0x2E: return 'c';
+        case 0x2F: return 'v';
+        case 0x30: return 'b';
+        case 0x31: return 'n';
+        case 0x32: return 'm';
+        case 0x39: return ' ';
+        case 0x1C: return '\n';
+        case 0x0E: return '\b';
+        default:   return 0;
+    }
+}
+
 char console_getc(void) {
-    return 0;  // always return zero, override as needed
+    char c = 0;
+    while (!c) {
+        uint8_t sc = ps2kbd_read_scancode();
+        if (sc & 0x80) continue; // ignore releases
+        c = scancode_to_ascii(sc);
+    }
+    return c;
 }

--- a/linkdep/io.c
+++ b/linkdep/io.c
@@ -1,0 +1,15 @@
+#include <stdint.h>
+
+void io_outb(uint16_t port, uint8_t val) {
+    __asm__ volatile ("outb %0, %1" : : "a"(val), "Nd"(port));
+}
+
+uint8_t io_inb(uint16_t port) {
+    uint8_t ret;
+    __asm__ volatile ("inb %1, %0" : "=a"(ret) : "Nd"(port));
+    return ret;
+}
+
+void io_wait(void) {
+    __asm__ volatile ("outb %%al, $0x80" : : "a"(0));
+}

--- a/linkdep/ps2kbd.c
+++ b/linkdep/ps2kbd.c
@@ -1,0 +1,14 @@
+#include <stdint.h>
+#include "io.h"
+
+#define KBD_DATA   0x60
+#define KBD_STATUS 0x64
+
+static void kbd_wait_read(void) {
+    while (!(io_inb(KBD_STATUS) & 1)) {}
+}
+
+uint8_t ps2kbd_read_scancode(void) {
+    kbd_wait_read();
+    return io_inb(KBD_DATA);
+}


### PR DESCRIPTION
## Summary
- add `io` helpers for port I/O
- implement PS/2 keyboard module
- improve `console_getc` with scancode translation
- note new modules in release notes

## Testing
- `bash tests/test_mem.sh`
- `bash build.sh` *(fails: missing cross compiler packages)*

------
https://chatgpt.com/codex/tasks/task_e_6840653fa04483309c5e1174c73c67b8