### PR TITLE
Add console_uhex helper

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,6 +11,8 @@
 - Static `io` helpers simplify port I/O access
 - Shared `panic` routine for consistent fatal error reporting
 - Build script supports multiple architectures and defaults to 64-bit
+- New `console_uhex` function for hexadecimal output
+- Kernel prints module addresses and entry points in hex
 
 ## New Features
 - Example `memtest` module using new API

--- a/include/console.h
+++ b/include/console.h
@@ -15,4 +15,7 @@ void console_puts(const char *s);
 /** Output an unsigned decimal number. */
 void console_udec(uint32_t v);
 
+/** Output an unsigned hexadecimal number. */
+void console_uhex(uint64_t val);
+
 #endif /* CONSOLE_H */

--- a/kernel/console.c
+++ b/kernel/console.c
@@ -43,3 +43,18 @@ void console_udec(uint32_t v) {
     }
     console_puts(&buf[i+1]);
 }
+
+void console_uhex(uint64_t val) {
+    char buf[17];
+    int i = 15;
+    const char *hex = "0123456789ABCDEF";
+    buf[16] = '\0';
+    if (val == 0) {
+        buf[i--] = '0';
+    }
+    while (val) {
+        buf[i--] = hex[val & 0xF];
+        val >>= 4;
+    }
+    console_puts(&buf[i+1]);
+}

--- a/kernel/console.h
+++ b/kernel/console.h
@@ -12,6 +12,12 @@ void console_putc(char c);
 /* Print a null-terminated string to VGA. */
 void console_puts(const char *s);
 
+/* Print an unsigned decimal number. */
+void console_udec(uint32_t v);
+
+/* Print an unsigned hexadecimal number. */
+void console_uhex(uint64_t val);
+
 /* Delete the character before the cursor (like backspace). */
 void console_backspace(void);
 

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -75,7 +75,7 @@ void kernel_main(uint32_t magic, multiboot_info_t *mbi) {
         /* If not ELF, call raw */
         if (*(uint32_t*)base != ELF_MAGIC) {
             console_puts("  RAW-module -> jumping at 0x");
-            console_udec((uint32_t)(uintptr_t)base);
+            console_uhex((uint64_t)(uintptr_t)base);
             console_puts("\n");
             ((void(*)(void))base)();
             console_puts("  RAW-module returned\n");
@@ -100,7 +100,7 @@ void kernel_main(uint32_t magic, multiboot_info_t *mbi) {
         uintptr_t entry = (uintptr_t)base + (eh->e_entry - first_vaddr);
 
         console_puts("  Jumping to entry 0x");
-        console_udec((uint32_t)entry);
+        console_uhex((uint64_t)entry);
         console_puts("\n");
 
         ((void(*)(void))entry)();


### PR DESCRIPTION
## Summary
- implement `console_uhex` for 64-bit hexadecimal printing
- expose `console_uhex` in headers
- use `console_uhex` in kernel_main to show module addresses
- document the improvement in release notes

## Testing
- `./tests/test_mem.sh`

------
https://chatgpt.com/codex/tasks/task_e_68417f93919c8330a7cdb7e5539ee62f