### PR TITLE
Fix boot assembly and module build

### DIFF
--- a/arch/x86/boot.S
+++ b/arch/x86/boot.S
@@ -1,3 +1,4 @@
+.intel_syntax noprefix
 .section .multiboot
 .align 4
 .long 0x1BADB002       /* magic */
@@ -43,13 +44,17 @@ mov cr3, eax
 mov eax, cr0
 or eax, 0x80000001   /* PG | PE */
 mov cr0, eax
-ljmp $0x08, $long_mode_start
+jmp 0x08:long_mode_start
 
 setup_paging:
-mov dword ptr [pml4], pdpt | 3
-mov dword ptr [pml4+4], 0
-mov dword ptr [pdpt], pde | 3
-mov dword ptr [pdpt+4], 0
+  mov eax, pdpt
+  or eax, 3
+  mov dword ptr [pml4], eax
+  mov dword ptr [pml4+4], 0
+  mov eax, pde
+  or eax, 3
+  mov dword ptr [pdpt], eax
+  mov dword ptr [pdpt+4], 0
 mov ecx, 0
 1:
 mov eax, ecx

--- a/build.sh
+++ b/build.sh
@@ -121,8 +121,15 @@ for src in run/*.c; do
       -Iinclude -c "$src" -o "$obj"
 
   echo "Linking $obj + console stub + linkdep.a → $elf"
+  extra=""
+  if [ "$base" = "memtest" ]; then
+    # compile memory manager for standalone test
+    $CC $MODULE_FLAG -std=gnu99 -ffreestanding -O2 -nostdlib -nodefaultlibs \
+        -Iinclude -c kernel/mem.c -o run/memtest_mem.o
+    extra="run/memtest_mem.o"
+  fi
   $LD -m $LDARCH -Ttext 0x00110000 \
-      "$obj" run/console_mod.o ${DEP_OBJS:+run/linkdep.a} \
+      "$obj" run/console_mod.o ${DEP_OBJS:+run/linkdep.a} $extra \
       -o "$elf"
 done
 

--- a/linker.ld
+++ b/linker.ld
@@ -7,4 +7,5 @@ SECTIONS {
   .rodata     : { *(.rodata)   . = ALIGN(4); }
   .data       : { *(.data)     . = ALIGN(4); }
   .bss        : { *(.bss)      . = ALIGN(4); }
+  end = .;
 }


### PR DESCRIPTION
## Summary
- enable Intel assembly syntax in `boot.S`
- correct paging setup code and far jump
- compile memtest module with memory manager
- export `end` symbol from linker script

## Testing
- `bash tests/test_mem.sh`
- `bash build.sh` (choice `1`)


------
https://chatgpt.com/codex/tasks/task_e_68429fde68a8833091dbddd85336c4c0