### PR TITLE
Fix GRUB kernel detection

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,7 +1,7 @@
 # Release Notes
 
 ## Bug Fixes
-- None
+- Multiboot header now resides in the first load segment so GRUB can detect the kernel
 
 ## Improvements
 - Added priority-based ballooning allocator

--- a/linker.ld
+++ b/linker.ld
@@ -1,11 +1,15 @@
 ENTRY(start)
-
+PHDRS {
+  text PT_LOAD FLAGS(5);
+  data PT_LOAD FLAGS(6);
+}
 SECTIONS {
-  . = 1M;                    /* load at 1 MiB */
-  .multiboot : { *(.multiboot) }
-  .text       : { *(.text)     . = ALIGN(4); }
-  .rodata     : { *(.rodata)   . = ALIGN(4); }
-  .data       : { *(.data)     . = ALIGN(4); }
-  .bss        : { *(.bss)      . = ALIGN(4); }
+  .text 0x100000 : AT(0x100000) {
+    KEEP(*(.multiboot))
+    *(.text)
+  } :text
+  .rodata : { *(.rodata*) } :text
+  .data : { *(.data) } :data
+  .bss  : { *(.bss) } :data
   end = .;
 }


### PR DESCRIPTION
## Summary
- ensure the multiboot header sits in the first load segment so GRUB can find it
- update release notes with the bug fix entry

## Testing
- `./build.sh`

------
https://chatgpt.com/codex/tasks/task_e_6842ecfe42b883308e211b5cb011c842