### PR TITLE
Fix GRUB kernel detection

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,7 +1,7 @@
 # Release Notes
 
 ## Bug Fixes
-- None
+- Multiboot header now resides in the first load segment so GRUB can detect the kernel
 
 ## Improvements
 - Added priority-based ballooning allocator

--- a/linker.ld
+++ b/linker.ld
@@ -1,10 +1,9 @@
 ENTRY(start)
-
 SECTIONS {
   . = 1M;                    /* load at 1 MiB */
-  .multiboot : { *(.multiboot) }
+  .multiboot : { KEEP(*(.multiboot)) }
   .text       : { *(.text)     . = ALIGN(4); }
-  .rodata     : { *(.rodata)   . = ALIGN(4); }
+  .rodata     : { *(.rodata*)  . = ALIGN(4); }
   .data       : { *(.data)     . = ALIGN(4); }
   .bss        : { *(.bss)      . = ALIGN(4); }
   end = .;


### PR DESCRIPTION
## Summary
- ensure multiboot header sits at the start of kernel
- revert to simpler linker script to avoid boot crash

## Testing
- `./build.sh`


------
https://chatgpt.com/codex/tasks/task_e_6842ecfe42b883308e211b5cb011c842