### PR TITLE
Fix boot crash on x86_64

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 ## Bug Fixes
 - Multiboot header now resides in the first load segment so GRUB can detect the kernel
+- Fixed reboot during boot by always assembling boot.S in 32-bit mode for 64-bit builds
 
 ## Improvements
 - Added priority-based ballooning allocator

--- a/build.sh
+++ b/build.sh
@@ -143,7 +143,11 @@ done
 
 # 8) Compile & assemble the kernel
 echo "Compiling kernel..."
-$CC $ARCH_FLAG -std=gnu99 -ffreestanding -O2 -Wall -Iinclude \
+BOOT_ARCH="$ARCH_FLAG"
+if [ "$ARCH_FLAG" = "-m64" ]; then
+  BOOT_ARCH="-m32"
+fi
+$CC $BOOT_ARCH -std=gnu99 -ffreestanding -O2 -Wall -Iinclude \
     -c arch/x86/boot.S   -o arch/x86/boot.o
 $CC $ARCH_FLAG -std=gnu99 -ffreestanding -O2 -Wall -Iinclude \
     -c arch/x86/idt.S    -o arch/x86/idt.o


### PR DESCRIPTION
## Summary
- ensure boot.S is assembled in 32-bit mode whenever building a 64-bit kernel
- document boot fix

## Testing
- `./tests/test_mem.sh`


------
https://chatgpt.com/codex/tasks/task_e_6842f5b66a548330a2dc036a54f6c295