### PR TITLE
Fix boot crash on x86_64

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 ## Bug Fixes
 - Multiboot header now resides in the first load segment so GRUB can detect the kernel
+- Fixed reboot during boot by assembling boot.S in 32-bit mode only when using the cross x86_64 toolchain
+- QEMU run mode is now headless to avoid GTK initialization failures
 
 ## Improvements
 - Added priority-based ballooning allocator

--- a/build.sh
+++ b/build.sh
@@ -143,7 +143,12 @@ done
 
 # 8) Compile & assemble the kernel
 echo "Compiling kernel..."
-$CC $ARCH_FLAG -std=gnu99 -ffreestanding -O2 -Wall -Iinclude \
+BOOT_ARCH="$ARCH_FLAG"
+if [ "$arch_choice" = "3" ]; then
+  # assemble boot.S in 32-bit mode for cross x86_64 target
+  BOOT_ARCH="-m32"
+fi
+$CC $BOOT_ARCH -std=gnu99 -ffreestanding -O2 -Wall -Iinclude \
     -c arch/x86/boot.S   -o arch/x86/boot.o
 $CC $ARCH_FLAG -std=gnu99 -ffreestanding -O2 -Wall -Iinclude \
     -c arch/x86/idt.S    -o arch/x86/idt.o
@@ -207,7 +212,8 @@ if [ "$1" = "run" ]; then
   $QEMU -cdrom exocore.iso \
        -boot order=d \
        -serial stdio \
-       -monitor none
+       -monitor none \
+       -nographic
 else
   echo "Done, use './build.sh run' to build & boot with serial debug"
 fi


### PR DESCRIPTION
## Summary
- ensure boot.S only uses -m32 when cross compiling with the x86_64 toolchain
- document the conditional build logic
- run QEMU headless to avoid GUI errors

## Testing
- `bash tests/test_mem.sh`
- `bash build.sh` (host build)
- `bash build.sh run` (failed to display output in this environment)


------
https://chatgpt.com/codex/tasks/task_e_6842f5b66a548330a2dc036a54f6c295