### PR TITLE
Fix boot script typo

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 ## Bug Fixes
 - Multiboot header now resides in the first load segment so GRUB can detect the kernel
+- Corrected typo in `build.sh` that prevented kernel compilation
+- Boot code is forced to 32-bit mode on x86_64 builds, preventing early reboot
 
 ## Improvements
 - Added priority-based ballooning allocator

--- a/build.sh
+++ b/build.sh
@@ -144,7 +144,9 @@ done
 # 8) Compile & assemble the kernel
 echo "Compiling kernel..."
 BOOT_ARCH="$ARCH_FLAG"
-if [ "$arch_choice" = "3" ]; thenm
+if [ "$arch_choice" = "1" ] || [ "$arch_choice" = "3" ]; then
+  # GRUB loads the kernel in 32-bit mode. Always build boot code as 32-bit
+  # when targeting any x86 or x86_64 environment.
   BOOT_ARCH="-m32"
 fi
 $CC $BOOT_ARCH -std=gnu99 -ffreestanding -O2 -Wall -Iinclude \


### PR DESCRIPTION
## Summary
- fix x86 boot code compilation on 64-bit builds
- update release notes with bug fix entry

## Testing
- `bash tests/test_mem.sh`


------
https://chatgpt.com/codex/tasks/task_e_6843063be4dc83308447a2cbc0544ff6