### PR TITLE
Improve build script reliability

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Install the following on Ubuntu (or a similar Linux distribution):
 * Cross‑compiler (e.g. `x86_64-elf-gcc`)
 * Binutils cross tools (`x86_64-elf-ld`)
 * NASM (for assembly modules)
-* `grub-mkrescue` (to create the bootable ISO)
+* `grub-mkrescue` and `mtools` (required for ISO generation)
 * `qemu-system-x86_64` (or your emulator of choice)
 * `make`, `bash`, and standard Unix utilities
 
@@ -41,6 +41,8 @@ Install the following on Ubuntu (or a similar Linux distribution):
    chmod +x build.sh
    ./build.sh
    ```
+
+   When executed, `build.sh` automatically checks for updates from the GitHub repository and offers to apply them before building.
 
    This will clean previous builds, compile the kernel stub, build all `.c` files in `run/`, link with GRUB, and produce `exocore.iso`.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -28,4 +28,8 @@
 ## Minor Fixes
 - Resolved pointer-size warnings in module loader
 - Added final newline to linker script
+- Build script installs `mtools` when missing, resolving "mformat" failures
+
+## Additional Improvements
+- `build.sh` checks for upstream updates and can automatically pull them
 


### PR DESCRIPTION
## Summary
- add automatic repo update check to `build.sh`
- ensure `grub-mkrescue` and mtools are installed
- document prerequisites and update behaviour
- update release notes

## Testing
- `bash tests/test_mem.sh`
- `bash build.sh <<'EOF'
1
EOF`

------
https://chatgpt.com/codex/tasks/task_e_684cfae3f2f08330a33a8d6329a5d9ed