### PR TITLE
Improve build script reliability

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Install the following on Ubuntu (or a similar Linux distribution):
 * Cross‑compiler (e.g. `x86_64-elf-gcc`)
 * Binutils cross tools (`x86_64-elf-ld`)
 * NASM (for assembly modules)
-* `grub-mkrescue` (to create the bootable ISO)
+* `grub-mkrescue` and `mtools` (required for ISO generation)
 * `qemu-system-x86_64` (or your emulator of choice)
 * `make`, `bash`, and standard Unix utilities
 
@@ -41,6 +41,8 @@ Install the following on Ubuntu (or a similar Linux distribution):
    chmod +x build.sh
    ./build.sh
    ```
+
+   When executed, `build.sh` automatically checks for updates from the GitHub repository and offers to apply them before building. It also installs required packages such as `nasm`, `grub-mkrescue`, `mtools`, and `qemu` if they are missing.
 
    This will clean previous builds, compile the kernel stub, build all `.c` files in `run/`, link with GRUB, and produce `exocore.iso`.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -28,4 +28,10 @@
 ## Minor Fixes
 - Resolved pointer-size warnings in module loader
 - Added final newline to linker script
+- Build script installs `mtools` when missing, resolving "mformat" failures
+- Build script installs remaining prerequisites (cross compilers, NASM, GRUB,
+  QEMU) automatically if absent
+
+## Additional Improvements
+- `build.sh` checks for upstream updates and can automatically pull them
 


### PR DESCRIPTION
## Summary
- auto-install missing packages via helper function
- ensure QEMU is installed if absent
- document automatic installation in README
- note auto-installation improvement in release notes

## Testing
- `bash tests/test_mem.sh`
- `bash build.sh <<'EOF'
1
EOF`


------
https://chatgpt.com/codex/tasks/task_e_684cfae3f2f08330a33a8d6329a5d9ed