### PR TITLE
Add memutils and QEMU debug flags

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -221,13 +221,15 @@ $CC $ARCH_FLAG -std=gnu99 -ffreestanding -O2 -Wall -Iinclude \
     -c kernel/idt.c     -o kernel/idt.o
 $CC $ARCH_FLAG -std=gnu99 -ffreestanding -O2 -Wall -Iinclude \
     -c kernel/panic.c   -o kernel/panic.o
+$CC $ARCH_FLAG -std=gnu99 -ffreestanding -O2 -Wall -Iinclude \
+    -c kernel/memutils.c -o kernel/memutils.o
 
 # 9) Link into flat kernel.bin
 echo "Linking kernel.bin..."
 $LD -m $LDARCH -T linker.ld \
     arch/x86/boot.o arch/x86/idt.o \
     kernel/main.o kernel/mem.o kernel/console.o \
-    kernel/idt.o kernel/panic.o \
+    kernel/idt.o kernel/panic.o kernel/memutils.o \
     -o kernel.bin
 
 # 10) Prepare ISO tree
@@ -271,7 +273,8 @@ if [ "$1" = "run" ]; then
   $QEMU -cdrom exocore.iso \
        -boot order=d \
        -serial stdio \
-       -monitor none
+       -monitor none \
+       -no-reboot -d int,cpu_reset
 else
   echo "Done, use './build.sh run' to build & boot with serial debug"
 fi

--- a/include/memutils.h
+++ b/include/memutils.h
@@ -1,0 +1,6 @@
+#ifndef MEMUTILS_H
+#define MEMUTILS_H
+#include <stddef.h>
+void *memcpy(void *dst, const void *src, size_t n);
+void *memset(void *dst, int val, size_t n);
+#endif /* MEMUTILS_H */

--- a/kernel/memutils.c
+++ b/kernel/memutils.c
@@ -1,0 +1,14 @@
+#include <stddef.h>
+void *memcpy(void *dst, const void *src, size_t n) {
+    unsigned char *d = dst;
+    const unsigned char *s = src;
+    for (size_t i = 0; i < n; i++)
+        d[i] = s[i];
+    return dst;
+}
+void *memset(void *dst, int val, size_t n) {
+    unsigned char *d = dst;
+    for (size_t i = 0; i < n; i++)
+        d[i] = (unsigned char)val;
+    return dst;
+}


### PR DESCRIPTION
## Summary
- implement `memcpy` and `memset` in new `memutils` module
- compile/link `memutils` in the build script
- run QEMU with `-no-reboot` and debugging flags for easier crash diagnosis

## Testing
- `bash tests/test_mem.sh`


------
https://chatgpt.com/codex/tasks/task_e_684ebb7581c483309cdf146659115ba2