### PR TITLE
Fix triple fault on boot

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,7 @@
 ## Bug Fixes
 - Multiboot header now resides in the first load segment so GRUB can detect the kernel
 - Corrected typo in `build.sh` that prevented kernel compilation
+- Fixed page table setup in `boot.S` so CR3 is loaded with the page directory base, preventing early triple faults
 
 ## Improvements
 - Added priority-based ballooning allocator

--- a/arch/x86/boot.S
+++ b/arch/x86/boot.S
@@ -40,12 +40,15 @@ mov ecx, 0xC0000080
 rdmsr
 or eax, 0x100        /* LME */
 wrmsr
-mov eax, pml4
+mov eax, OFFSET pml4
 mov cr3, eax
 mov eax, cr0
 or eax, 0x80000001   /* PG | PE */
 mov cr0, eax
-jmp 0x08:long_mode_start
+    /* Far jump to 64-bit mode */
+    .byte 0xEA
+    .long long_mode_start
+    .word 0x08
 
 setup_paging:
   /* Identity map the first 1 GiB using 2 MiB pages */
@@ -59,11 +62,11 @@ setup_paging:
   inc ecx
   cmp ecx, 512
   jne 1b
-  mov eax, pd
+  mov eax, OFFSET pd
   or eax, 3
   mov dword ptr [pdpt], eax
   mov dword ptr [pdpt+4], 0
-  mov eax, pdpt
+  mov eax, OFFSET pdpt
   or eax, 3
   mov dword ptr [pml4], eax
   mov dword ptr [pml4+4], 0


### PR DESCRIPTION
## Summary
- correct boot page table setup
- update release notes

## Testing
- `./build.sh run` *(fails: gtk initialization failed)*

------
https://chatgpt.com/codex/tasks/task_e_684ec77ada448330841327808e536060