### PR TITLE
Fix boot stack LEA syntax

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,7 @@
 - Corrected typo in `build.sh` that prevented kernel compilation
 - Fixed page table setup in `boot.S` so CR3 is loaded with the page directory base, preventing early triple faults
 - Corrected stack pointer initialization in `boot.S` which caused a page fault and system reset
+- Fixed invalid `lea` operand syntax in `boot.S` that broke the 64-bit stack setup
 
 ## Improvements
 - Added priority-based ballooning allocator

--- a/arch/x86/boot.S
+++ b/arch/x86/boot.S
@@ -89,7 +89,7 @@ mov es, ax
 mov ss, ax
 mov fs, ax
 mov gs, ax
-lea rsp, [rel stack + 8192]
+lea rsp, [stack + 8192]
 mov rdi, [multiboot_magic]
 mov rsi, [multiboot_info]
 call kernel_main


### PR DESCRIPTION
## Summary
- fix stack pointer setup instruction in boot.S
- document fix in release notes

## Testing
- `bash tests/test_mem.sh`
- `bash build.sh <<'EOF'
1
EOF`

------
https://chatgpt.com/codex/tasks/task_e_684ecbaae0ec8330ba3e78b9e375a7d1