### PR TITLE
Integrate stable 0.5.1 boot sequence

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,8 @@
 - Fixed page table setup in `boot.S` so CR3 is loaded with the page directory base, preventing early triple faults
 - Corrected stack pointer initialization in `boot.S` which caused a page fault and system reset
 - Fixed invalid `lea` operand syntax in `boot.S` that broke the 64-bit stack setup
+- Reworked boot manager using the simpler 0.5.1 entry logic while still
+  transitioning to long mode, eliminating startup triple faults
 
 ## Improvements
 - Added priority-based ballooning allocator

--- a/arch/x86/boot.S
+++ b/arch/x86/boot.S
@@ -28,27 +28,33 @@ multiboot_info:
 .code32
 .global start
 start:
-cli
-mov [multiboot_magic], eax
-mov [multiboot_info], ebx
-call setup_paging
-lgdt gdt64_ptr
-mov eax, cr4
-or eax, 0x20         /* enable PAE */
-mov cr4, eax
-mov ecx, 0xC0000080
-rdmsr
-or eax, 0x100        /* LME */
-wrmsr
-mov eax, OFFSET pml4
-mov cr3, eax
-mov eax, cr0
-or eax, 0x80000001   /* PG | PE */
-mov cr0, eax
-    /* Far jump to 64-bit mode */
-    .byte 0xEA
-    .long long_mode_start
-    .word 0x08
+    cli
+    /* Preserve Multiboot registers like v0.5.1 */
+    push ebx            /* mbi pointer */
+    push eax            /* magic */
+    call enter64
+
+/* Enable paging and switch to long mode */
+enter64:
+    pop eax             /* magic */
+    pop ebx             /* mbi pointer */
+    mov [multiboot_magic], eax
+    mov [multiboot_info], ebx
+    call setup_paging
+    lgdt gdt64_ptr
+    mov eax, cr4
+    or eax, 0x20        /* enable PAE */
+    mov cr4, eax
+    mov ecx, 0xC0000080
+    rdmsr
+    or eax, 0x100       /* LME */
+    wrmsr
+    mov eax, OFFSET pml4
+    mov cr3, eax
+    mov eax, cr0
+    or eax, 0x80000001  /* PG | PE */
+    mov cr0, eax
+    jmp 0x08:long_mode_start
 
 setup_paging:
   /* Identity map the first 1 GiB using 2 MiB pages */


### PR DESCRIPTION
## Summary
- simplify boot transition with 0.5.1 logic
- keep 64-bit long mode entry
- note boot manager refactor in release notes

## Testing
- `bash tests/test_mem.sh`
- `./build.sh < 1`

------
https://chatgpt.com/codex/tasks/task_e_684fc16596548330bd34dedb8e9db3fa