### PR TITLE
Add early IDT init and serial logging

### DIFF
--- a/arch/x86/boot.S
+++ b/arch/x86/boot.S
@@ -26,6 +26,7 @@ multiboot_info:
 
 .section .text
 .code32
+.extern idt_init
 .global start
 start:
 cli
@@ -90,6 +91,7 @@ mov ss, ax
 mov fs, ax
 mov gs, ax
 lea rsp, [stack + 8192]
+call idt_init
 mov rdi, [multiboot_magic]
 mov rsi, [multiboot_info]
 call kernel_main

--- a/build.sh
+++ b/build.sh
@@ -218,6 +218,8 @@ $CC $ARCH_FLAG -std=gnu99 -ffreestanding -O2 -Wall -Iinclude \
 $CC $ARCH_FLAG -std=gnu99 -ffreestanding -O2 -Wall -Iinclude \
     -c kernel/console.c -o kernel/console.o
 $CC $ARCH_FLAG -std=gnu99 -ffreestanding -O2 -Wall -Iinclude \
+    -c kernel/serial.c -o kernel/serial.o
+$CC $ARCH_FLAG -std=gnu99 -ffreestanding -O2 -Wall -Iinclude \
     -c kernel/idt.c     -o kernel/idt.o
 $CC $ARCH_FLAG -std=gnu99 -ffreestanding -O2 -Wall -Iinclude \
     -c kernel/panic.c   -o kernel/panic.o
@@ -228,7 +230,7 @@ $CC $ARCH_FLAG -std=gnu99 -ffreestanding -O2 -Wall -Iinclude \
 echo "Linking kernel.bin..."
 $LD -m $LDARCH -T linker.ld \
     arch/x86/boot.o arch/x86/idt.o \
-    kernel/main.o kernel/mem.o kernel/console.o \
+    kernel/main.o kernel/mem.o kernel/console.o kernel/serial.o \
     kernel/idt.o kernel/panic.o kernel/memutils.o \
     -o kernel.bin
 

--- a/include/serial.h
+++ b/include/serial.h
@@ -1,0 +1,9 @@
+#ifndef SERIAL_H
+#define SERIAL_H
+#include <stdint.h>
+void serial_init(void);
+void serial_putc(char c);
+void serial_write(const char *s);
+void serial_udec(uint32_t v);
+void serial_uhex(uint64_t val);
+#endif /* SERIAL_H */

--- a/kernel/idt.c
+++ b/kernel/idt.c
@@ -1,12 +1,32 @@
 #include "idt.h"
 #include "console.h"
 #include "panic.h"
+#include "serial.h"
 
 extern void idt_load(idt_ptr_t *);
 extern void *isr_stub_table[];
 
 static idt_entry_t idt[256];
 static irq_handler_t handlers[256];
+
+static inline void outb(uint16_t port, uint8_t val) {
+    __asm__ volatile ("outb %0, %1" : : "a"(val), "Nd"(port));
+}
+static inline uint8_t inb(uint16_t port) {
+    uint8_t val;
+    __asm__ volatile ("inb %1, %0" : "=a"(val) : "Nd"(port));
+    return val;
+}
+
+static void wait_keypress(void) {
+    while (!(inb(0x64) & 1)) {}
+    (void)inb(0x60);
+}
+
+static void reboot(void) {
+    outb(0x64, 0xFE);
+    for (;;) __asm__("hlt");
+}
 
 static void idt_set_gate(uint8_t num, uint64_t base, uint16_t sel, uint8_t flags) {
     idt[num].offset_low  = base & 0xFFFF;
@@ -32,7 +52,8 @@ void idt_init(void) {
 }
 
 void idt_handle_interrupt(uint32_t num, uint32_t err, uint64_t rsp) {
-    (void)rsp;
+    uint64_t *stack = (uint64_t*)rsp;
+    uint64_t rip = stack[17];
     if (handlers[num]) {
         handlers[num](num, err, rsp);
         return;
@@ -76,12 +97,37 @@ void idt_handle_interrupt(uint32_t num, uint32_t err, uint64_t rsp) {
     if (num < 32) {
         console_puts("EXCEPTION: ");
         console_puts(exc_msgs[num]);
+        console_puts(" at 0x");
+        console_uhex(rip);
+        console_puts(" err=0x");
+        console_uhex(err);
         console_puts("\n");
-        panic("CPU fault");
+
+        serial_write("EXCEPTION: ");
+        serial_write(exc_msgs[num]);
+        serial_write(" at 0x");
+        serial_uhex(rip);
+        serial_write(" err=0x");
+        serial_uhex(err);
+        serial_write("\n");
+
+        if (num == 14) {
+            console_puts("Press any key to reboot...\n");
+            serial_write("Press any key to reboot...\n");
+            wait_keypress();
+            reboot();
+        } else if (num == 3 || num == 1) {
+            return;
+        } else {
+            panic("Fatal exception");
+        }
     } else {
         console_puts("Unhandled IRQ ");
         console_udec(num);
         console_puts("\n");
+        serial_write("Unhandled IRQ ");
+        serial_udec(num);
+        serial_write("\n");
         panic("Unhandled IRQ");
     }
 }

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -8,31 +8,8 @@
 #include "mem.h"
 #include "panic.h"
 #include "idt.h"
+#include "serial.h"
 
-/* I/O port access for serial port COM1 */
-static inline void outb(uint16_t port, uint8_t val) {
-    __asm__ volatile ("outb %0, %1" : : "a"(val), "Nd"(port));
-}
-static inline uint8_t inb(uint16_t port) {
-    uint8_t val;
-    __asm__ volatile ("inb %1, %0" : "=a"(val) : "Nd"(port));
-    return val;
-}
-
-/* Serial console routines */
-static void serial_init(void) {
-    outb(0x3F8+1,0); outb(0x3F8+3,0x80);
-    outb(0x3F8+0,0x01); outb(0x3F8+1,0);
-    outb(0x3F8+3,0x03); outb(0x3F8+2,0xC7);
-    outb(0x3F8+4,0x0B);
-}
-static void serial_putc(char c) {
-    while (!(inb(0x3F8+5) & 0x20));
-    outb(0x3F8, c);
-}
-static void serial_write(const char *s) {
-    for (; *s; ++s) serial_putc(*s);
-}
 
 
 /* Entry point, called by boot.S (magic in RDI, mbi ptr in RSI) */

--- a/kernel/panic.c
+++ b/kernel/panic.c
@@ -1,30 +1,8 @@
 #include <stdint.h>
 #include "console.h"
 #include "panic.h"
+#include "serial.h"
 
-/* Serial I/O used for panic output */
-static inline void outb(uint16_t port, uint8_t val) {
-    __asm__ volatile ("outb %0, %1" : : "a"(val), "Nd"(port));
-}
-static inline uint8_t inb(uint16_t port) {
-    uint8_t val;
-    __asm__ volatile ("inb %1, %0" : "=a"(val) : "Nd"(port));
-    return val;
-}
-
-static void serial_init(void) {
-    outb(0x3F8+1,0); outb(0x3F8+3,0x80);
-    outb(0x3F8+0,0x01); outb(0x3F8+1,0);
-    outb(0x3F8+3,0x03); outb(0x3F8+2,0xC7);
-    outb(0x3F8+4,0x0B);
-}
-static void serial_putc(char c) {
-    while (!(inb(0x3F8+5) & 0x20));
-    outb(0x3F8, c);
-}
-static void serial_write(const char *s) {
-    for (; *s; ++s) serial_putc(*s);
-}
 
 void panic(const char *msg) {
     serial_init();

--- a/kernel/serial.c
+++ b/kernel/serial.c
@@ -1,0 +1,55 @@
+#include <stdint.h>
+#include "serial.h"
+
+static inline void outb(uint16_t port, uint8_t val) {
+    __asm__ volatile ("outb %0, %1" : : "a"(val), "Nd"(port));
+}
+static inline uint8_t inb(uint16_t port) {
+    uint8_t val;
+    __asm__ volatile ("inb %1, %0" : "=a"(val) : "Nd"(port));
+    return val;
+}
+
+void serial_init(void) {
+    outb(0x3F8 + 1, 0);
+    outb(0x3F8 + 3, 0x80);
+    outb(0x3F8 + 0, 0x01);
+    outb(0x3F8 + 1, 0);
+    outb(0x3F8 + 3, 0x03);
+    outb(0x3F8 + 2, 0xC7);
+    outb(0x3F8 + 4, 0x0B);
+}
+
+void serial_putc(char c) {
+    while (!(inb(0x3F8 + 5) & 0x20)) {}
+    outb(0x3F8, c);
+}
+
+void serial_write(const char *s) {
+    for (; *s; ++s) serial_putc(*s);
+}
+
+void serial_udec(uint32_t v) {
+    char buf[12];
+    int i = 10;
+    buf[11] = '\0';
+    if (v == 0) buf[i--] = '0';
+    while (v) {
+        buf[i--] = '0' + (v % 10);
+        v /= 10;
+    }
+    serial_write(&buf[i + 1]);
+}
+
+void serial_uhex(uint64_t val) {
+    char buf[17];
+    int i = 15;
+    const char *hex = "0123456789ABCDEF";
+    buf[16] = '\0';
+    if (val == 0) buf[i--] = '0';
+    while (val) {
+        buf[i--] = hex[val & 0xF];
+        val >>= 4;
+    }
+    serial_write(&buf[i + 1]);
+}


### PR DESCRIPTION
## Summary
- initialize the IDT in `boot.S` before `kernel_main`
- provide common serial helpers in new `serial` module
- update main and panic code to use the shared serial functions
- extend interrupt handler to print detailed info and allow reboot
- compile the new serial module in `build.sh`

## Testing
- `bash build.sh` with host compiler


------
https://chatgpt.com/codex/tasks/task_e_684fc5367f208330b77c00800d97d51b