### PR TITLE
Add C linkage guards in headers

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,7 @@
 - Fixed page table setup in `boot.S` so CR3 is loaded with the page directory base, preventing early triple faults
 - Corrected stack pointer initialization in `boot.S` which caused a page fault and system reset
 - Fixed invalid `lea` operand syntax in `boot.S` that broke the 64-bit stack setup
+- Headers now use `extern "C"` guards, preventing unresolved symbols when linking with C++
 
 ## Improvements
 - Added priority-based ballooning allocator

--- a/include/console.h
+++ b/include/console.h
@@ -3,6 +3,10 @@
 
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /** Initialize the VGA text console (clears screen). */
 void console_init(void);
 
@@ -17,5 +21,9 @@ void console_udec(uint32_t v);
 
 /** Output an unsigned hexadecimal number. */
 void console_uhex(uint64_t val);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* CONSOLE_H */

--- a/include/elf.h
+++ b/include/elf.h
@@ -3,6 +3,10 @@
 #define ELF_H
 
 #include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 #define ELF_MAGIC 0x464C457F
 
 typedef struct {
@@ -40,5 +44,9 @@ typedef struct {
 } elf_phdr_t;
 
 #define PT_LOAD 1
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ELF_H */

--- a/include/idt.h
+++ b/include/idt.h
@@ -3,6 +3,10 @@
 
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct {
     uint16_t offset_low;
     uint16_t selector;
@@ -23,5 +27,9 @@ typedef void (*irq_handler_t)(uint32_t num, uint32_t err, uint64_t rsp);
 void idt_init(void);
 void register_irq_handler(uint8_t num, irq_handler_t handler);
 void idt_handle_interrupt(uint32_t num, uint32_t err, uint64_t rsp);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* IDT_H */

--- a/include/io.h
+++ b/include/io.h
@@ -2,8 +2,16 @@
 #define IO_H
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void io_outb(uint16_t port, uint8_t val);
 uint8_t io_inb(uint16_t port);
 void io_wait(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* IO_H */

--- a/include/mem.h
+++ b/include/mem.h
@@ -3,6 +3,11 @@
 
 #include <stdint.h>
 #include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void mem_init(uintptr_t heap_start, size_t heap_size);
 void *mem_alloc(size_t size);
 
@@ -10,5 +15,9 @@ void *mem_alloc(size_t size);
 int  mem_register_app(uint8_t priority);
 void *mem_alloc_app(int app_id, size_t size);
 size_t mem_app_used(int app_id);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* MEM_H */

--- a/include/memutils.h
+++ b/include/memutils.h
@@ -1,6 +1,16 @@
 #ifndef MEMUTILS_H
 #define MEMUTILS_H
 #include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void *memcpy(void *dst, const void *src, size_t n);
 void *memset(void *dst, int val, size_t n);
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* MEMUTILS_H */

--- a/include/multiboot.h
+++ b/include/multiboot.h
@@ -3,6 +3,10 @@
 
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define MULTIBOOT_BOOTLOADER_MAGIC 0x2BADB002
 
 typedef struct {
@@ -20,5 +24,9 @@ typedef struct {
     uint32_t mods_count;
     uint32_t mods_addr;
 } multiboot_info_t;
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* MULTIBOOT_H */

--- a/include/panic.h
+++ b/include/panic.h
@@ -1,6 +1,14 @@
 #ifndef PANIC_H
 #define PANIC_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void panic(const char *msg);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* PANIC_H */

--- a/include/ps2kbd.h
+++ b/include/ps2kbd.h
@@ -2,6 +2,14 @@
 #define PS2KBD_H
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 uint8_t ps2kbd_read_scancode(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* PS2KBD_H */

--- a/include/serial.h
+++ b/include/serial.h
@@ -1,9 +1,19 @@
 #ifndef SERIAL_H
 #define SERIAL_H
 #include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void serial_init(void);
 void serial_putc(char c);
 void serial_write(const char *s);
 void serial_udec(uint32_t v);
 void serial_uhex(uint64_t val);
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* SERIAL_H */


### PR DESCRIPTION
## Summary
- wrap public headers with `extern "C"` when included from C++
- document fix in release notes

## Testing
- `./build.sh`
- `bash tests/test_mem.sh`

------
https://chatgpt.com/codex/tasks/task_e_684fce7628d48330a2a19d978aaa16be