### PR TITLE
Add kernel tester and userland boot modes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -37,3 +37,8 @@
 ## Additional Improvements
 - `build.sh` checks for upstream updates and can automatically pull them
 
+
+## New Features
+- Automatic "kernel tester" module validates 64-bit mode and library linkage
+- New GRUB entries: "ExoCore-Kernel (Debug)" enables verbose serial/VGA logs and "ExoCore-OS (alpha)" boots userland modules
+- Build script compiles userland modules and packages them separately

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -1,6 +1,7 @@
 // kernel/main.c
 
 #include <stdint.h>
+#include <string.h>
 #include "multiboot.h"
 #include "config.h"
 #include "elf.h"
@@ -9,6 +10,19 @@
 #include "panic.h"
 #include "idt.h"
 #include "serial.h"
+
+static int debug_mode = 0;
+static int userland_mode = 0;
+
+static void parse_cmdline(const char *cmd) {
+    if (!cmd) return;
+    for (const char *p = cmd; *p; p++) {
+        if (!debug_mode && !strncmp(p, "debug", 5))
+            debug_mode = 1;
+        if (!userland_mode && !strncmp(p, "userland", 8))
+            userland_mode = 1;
+    }
+}
 
 
 
@@ -21,9 +35,21 @@ void kernel_main(uint32_t magic, multiboot_info_t *mbi) {
     mem_init((uintptr_t)&end, 128 * 1024);
     idt_init();
 
+    if (mbi->flags & (1 << 2)) { // cmdline present
+        parse_cmdline((const char*)(uintptr_t)mbi->cmdline);
+    }
+
+    if (debug_mode && userland_mode) {
+        serial_write("Userland mode enabled\n");
+    }
+
     /* 2) Banner */
     serial_write("ExoCore booted\n");
-    console_puts ("ExoCore booted\n");
+    console_puts("ExoCore booted\n");
+    if (debug_mode) {
+        serial_write("Debug mode enabled\n");
+        console_puts("Debug mode enabled\n");
+    }
 
     /* 3) Multiboot check */
     if (magic != MULTIBOOT_BOOTLOADER_MAGIC) {
@@ -44,23 +70,33 @@ void kernel_main(uint32_t magic, multiboot_info_t *mbi) {
     /* 5) Load & execute modules in-place */
     multiboot_module_t *mods = (multiboot_module_t*)(uintptr_t)mbi->mods_addr;
     for (uint32_t i = 0; i < mbi->mods_count; i++) {
+        const char *mstr = (const char*)(uintptr_t)mods[i].string;
+        int is_user = (mstr && !strncmp(mstr, "userland", 8));
+        if (userland_mode ? !is_user : is_user) {
+            continue;
+        }
+
         uint8_t *base = (uint8_t*)(uintptr_t)mods[i].mod_start;
 
         /* Debug header */
         console_puts("Module "); console_udec(i); console_puts("\n");
+        if (debug_mode) { serial_write("Module "); serial_udec(i); serial_write("\n"); }
 
         /* If not ELF, call raw */
         if (*(uint32_t*)base != ELF_MAGIC) {
-            console_puts("  RAW-module -> jumping at 0x");
-            console_uhex((uint64_t)(uintptr_t)base);
-            console_puts("\n");
+        console_puts("  RAW-module -> jumping at 0x");
+        console_uhex((uint64_t)(uintptr_t)base);
+        console_puts("\n");
+        if (debug_mode) { serial_write("  RAW-module -> jumping at 0x"); serial_uhex((uint64_t)(uintptr_t)base); serial_write("\n"); }
             ((void(*)(void))base)();
-            console_puts("  RAW-module returned\n");
+        console_puts("  RAW-module returned\n");
+        if (debug_mode) serial_write("  RAW-module returned\n");
             continue;
         }
 
         /* ELF in-place */
         console_puts("  ELF-module\n");
+        if (debug_mode) serial_write("  ELF-module\n");
         elf_header_t *eh = (elf_header_t*)base;
         elf_phdr_t   *ph = (elf_phdr_t*)(base + eh->e_phoff);
 
@@ -79,14 +115,17 @@ void kernel_main(uint32_t magic, multiboot_info_t *mbi) {
         console_puts("  Jumping to entry 0x");
         console_uhex((uint64_t)entry);
         console_puts("\n");
+        if (debug_mode) { serial_write("  Jumping to entry 0x"); serial_uhex((uint64_t)entry); serial_write("\n"); }
 
         ((void(*)(void))entry)();
         console_puts("  ELF-module returned\n");
+        if (debug_mode) serial_write("  ELF-module returned\n");
     }
 #else
     console_puts("FEATURE_RUN_DIR disabled\n");
 #endif
 
     console_puts("All done, halting\n");
+    if (debug_mode) serial_write("All done, halting\n");
     for (;;) __asm__("hlt");
 }

--- a/run/00_kernel_tester.c
+++ b/run/00_kernel_tester.c
@@ -1,0 +1,31 @@
+#include <stdint.h>
+#include "console.h"
+#include "serial.h"
+
+/* Manual declaration from linkdep */
+extern uint32_t example_compute(uint32_t x, uint32_t y);
+
+void _start() {
+    console_puts("[test] Kernel tester running\n");
+    serial_write("[test] Kernel tester running\n");
+
+    /* Verify library linkage */
+    uint32_t val = example_compute(2, 3);
+    console_puts("[test] example_compute result: ");
+    console_udec(val);
+    console_putc('\n');
+    serial_write("[test] example_compute result: ");
+    serial_udec(val);
+    serial_putc('\n');
+
+    /* Check long mode */
+    if (sizeof(void*) == 8) {
+        console_puts("[test] 64-bit mode OK\n");
+        serial_write("[test] 64-bit mode OK\n");
+    } else {
+        console_puts("[test] 64-bit mode FAILED\n");
+        serial_write("[test] 64-bit mode FAILED\n");
+    }
+
+    for (;;) __asm__("hlt");
+}

--- a/run/userland/00_hello.c
+++ b/run/userland/00_hello.c
@@ -1,0 +1,7 @@
+#include <stdint.h>
+#include "console.h"
+
+void _start() {
+    console_puts("[user] Hello from userland 00\n");
+    for (;;) __asm__("hlt");
+}

--- a/run/userland/01_second.c
+++ b/run/userland/01_second.c
@@ -1,0 +1,7 @@
+#include <stdint.h>
+#include "console.h"
+
+void _start() {
+    console_puts("[user] Second userland app\n");
+    for (;;) __asm__("hlt");
+}


### PR DESCRIPTION
## Summary
- add `00_kernel_tester` module for early runtime checks
- support debug and userland modes via kernel command line
- build userland apps and new GRUB menu entries
- document new features in release notes

## Testing
- `bash tests/test_mem.sh`
- `yes 3 | ./build.sh` *(fails: Unable to locate package binutils-x86-64-elf gcc-x86-64-elf)*

------
https://chatgpt.com/codex/tasks/task_e_6850219e72808330a1eabc227355aa74