### PR TITLE
Fix undefined serial symbols in modules

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,6 +7,7 @@
 - Corrected stack pointer initialization in `boot.S` which caused a page fault and system reset
 - Fixed invalid `lea` operand syntax in `boot.S` that broke the 64-bit stack setup
 - Headers now use `extern "C"` guards, preventing unresolved symbols when linking with C++
+- Fixed undefined references in `00_kernel_tester` by linking serial stubs and adding `strncmp`
 
 ## Improvements
 - Added priority-based ballooning allocator
@@ -20,6 +21,7 @@
 - New `console_uhex` function for hexadecimal output
 - Kernel prints module addresses and entry points in hex
 - Modules build with `-m64` when using the x86_64 toolchain
+- Modules now link against a serial stub for debugging output
 
 ## New Features
 - Example `memtest` module using new API

--- a/include/memutils.h
+++ b/include/memutils.h
@@ -8,6 +8,7 @@ extern "C" {
 
 void *memcpy(void *dst, const void *src, size_t n);
 void *memset(void *dst, int val, size_t n);
+int strncmp(const char *s1, const char *s2, size_t n);
 
 #ifdef __cplusplus
 }

--- a/kernel/memutils.c
+++ b/kernel/memutils.c
@@ -12,3 +12,15 @@ void *memset(void *dst, int val, size_t n) {
         d[i] = (unsigned char)val;
     return dst;
 }
+
+int strncmp(const char *s1, const char *s2, size_t n) {
+    for (size_t i = 0; i < n; i++) {
+        unsigned char c1 = s1[i];
+        unsigned char c2 = s2[i];
+        if (c1 != c2)
+            return c1 - c2;
+        if (c1 == '\0')
+            return 0;
+    }
+    return 0;
+}


### PR DESCRIPTION
## Summary
- build serial stub so modules can print over COM ports
- link serial stub when building run/ modules
- implement `strncmp` in `memutils`
- document fixes and improvements in RELEASE_NOTES

## Testing
- `./build.sh <<'EOF'
1
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6850280ecfd88330a002119b5fc3c014