### PR TITLE
Fix 64-bit stack alignment

### DIFF
--- a/arch/x86/boot.S
+++ b/arch/x86/boot.S
@@ -101,7 +101,7 @@ long_mode_start:
     mov ss, ax
     mov fs, ax
     mov gs, ax
-    lea rsp, [stack + 8192]
+    lea rsp, [stack + 8192 - 8]  # ensure 16-byte stack alignment for C calls
     /* Prepare GDT with TSS descriptor */
     lea rax, [tss64]
     mov word ptr [gdt64 + 24], (104 - 1)        # limit low
@@ -120,7 +120,7 @@ long_mode_start:
     mov rcx, 104/8
     lea rdi, [tss64]
     rep stosq
-    lea rax, [stack + 8192]
+    lea rax, [stack + 8192 - 8]  # match RSP alignment
     mov [tss64 + 4], rax        # rsp0
     lea rax, [df_stack + 4096]
     mov [tss64 + 36], rax       # ist1


### PR DESCRIPTION
## Summary
- ensure the initial stack is 16-byte aligned

## Testing
- `bash tests/test_mem.sh`
- `timeout 10 qemu-system-x86_64 -cdrom exocore.iso -serial stdio -display none -no-reboot` *(boot test)*

------
https://chatgpt.com/codex/tasks/task_e_68503089d81c8330a0b222b14a8f26a5