### PR TITLE
Add crash source reporting

### DIFF
--- a/include/runstate.h
+++ b/include/runstate.h
@@ -1,0 +1,15 @@
+#ifndef RUNSTATE_H
+#define RUNSTATE_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern volatile const char *current_program;
+extern volatile int current_user_app;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* RUNSTATE_H */

--- a/kernel/idt.c
+++ b/kernel/idt.c
@@ -2,6 +2,7 @@
 #include "console.h"
 #include "panic.h"
 #include "serial.h"
+#include "runstate.h"
 
 extern void idt_load(idt_ptr_t *);
 extern void *isr_stub_table[];
@@ -121,6 +122,15 @@ void idt_handle_interrupt(uint32_t num, uint32_t err, uint64_t rsp) {
         } else if (num == 3 || num == 1) {
             return;
         } else {
+            const char *type = current_user_app ? "User app" : "Kernel process";
+            console_puts(type);
+            console_puts(" crashed: ");
+            console_puts(current_program);
+            console_putc('\n');
+            serial_write(type);
+            serial_write(" crashed: ");
+            serial_write(current_program);
+            serial_write("\n");
             panic("Fatal exception");
         }
     } else {

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -10,9 +10,12 @@
 #include "panic.h"
 #include "idt.h"
 #include "serial.h"
+#include "runstate.h"
 
 static int debug_mode = 0;
 static int userland_mode = 0;
+volatile const char *current_program = "kernel";
+volatile int current_user_app = 0;
 
 static void parse_cmdline(const char *cmd) {
     if (!cmd) return;
@@ -112,7 +115,11 @@ void kernel_main(uint32_t magic, multiboot_info_t *mbi) {
         console_puts("\n");
         if (debug_mode) { serial_write("  Jumping to entry 0x"); serial_uhex((uint64_t)entry); serial_write("\n"); }
 
+        current_program = mstr ? mstr : "module";
+        current_user_app = is_user;
         ((void(*)(void))entry)();
+        current_program = "kernel";
+        current_user_app = 0;
         console_puts("  ELF-module returned\n");
         if (debug_mode) serial_write("  ELF-module returned\n");
     }


### PR DESCRIPTION
## Summary
- track currently executing module
- report whether fatal exceptions occur in user apps or kernel processes

## Testing
- `bash tests/test_mem.sh`
- `printf '3\n' | ./build.sh`

------
https://chatgpt.com/codex/tasks/task_e_6850bad6629883309d920dcd277532db