### PR TITLE
Add optional nographic run mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ To build and launch QEMU in one step:
 ./build.sh run
 ```
 
+Use the optional `nographic` parameter to run QEMU without a graphical window:
+
+```bash
+./build.sh run nographic
+```
+
 Alternatively, after building, run QEMU manually:
 
 ```bash

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -39,6 +39,7 @@
 
 ## Additional Improvements
 - `build.sh` checks for upstream updates and can automatically pull them
+- QEMU run command now accepts an optional `nographic` argument
 
 
 ## New Features

--- a/build.sh
+++ b/build.sh
@@ -329,13 +329,21 @@ $GRUB -o exocore.iso isodir
 # 14) Run in QEMU if requested
 if [ "$1" = "run" ]; then
   echo "Booting in QEMU…"
-  $QEMU -cdrom exocore.iso \
-       -boot order=d \
-       -serial stdio \
-       -monitor none \
-       -no-reboot \
-       -display none
+  if [ "$2" = "nographic" ]; then
+    $QEMU -cdrom exocore.iso \
+         -boot order=d \
+         -serial stdio \
+         -monitor none \
+         -no-reboot \
+         -display none
+  else
+    $QEMU -cdrom exocore.iso \
+         -boot order=d \
+         -serial stdio \
+         -monitor none \
+         -no-reboot
+  fi
 else
-  echo "Done, use './build.sh run' to build & boot with serial debug"
+  echo "Done, use './build.sh run [nographic]' to build & boot"
 fi
 


### PR DESCRIPTION
## Summary
- allow `build.sh run nographic` to boot QEMU without a display
- document the new option in README
- note the change in release notes

## Testing
- `bash tests/test_mem.sh`

------
https://chatgpt.com/codex/tasks/task_e_6850c7bd82bc83308bfbf282fbf14a2d