### PR TITLE
Enhance kernel test integration

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -40,9 +40,11 @@
 ## Additional Improvements
 - `build.sh` checks for upstream updates and can automatically pull them
 - QEMU run command now accepts an optional `nographic` argument
+- QEMU command honors `QEMU_EXTRA` for additional debugging flags
 
 
 ## New Features
 - Automatic "kernel tester" module validates 64-bit mode and library linkage
 - New GRUB entries: "ExoCore-Kernel (Debug)" enables verbose serial/VGA logs and "ExoCore-OS (alpha)" boots userland modules
 - Build script compiles userland modules and packages them separately
+- Improved full kernel test script integrates with build.sh for detailed logs

--- a/build.sh
+++ b/build.sh
@@ -327,23 +327,25 @@ echo "Building ISO (modules: ${MODULES[*]} userland: ${USER_MODULES_BN[*]})..."
 $GRUB -o exocore.iso isodir
 
 # 14) Run in QEMU if requested
-if [ "$1" = "run" ]; then
-  echo "Booting in QEMU…"
-  if [ "$2" = "nographic" ]; then
-    $QEMU -cdrom exocore.iso \
-         -boot order=d \
-         -serial stdio \
-         -monitor none \
-         -no-reboot \
-         -display none
+  if [ "$1" = "run" ]; then
+    echo "Booting in QEMU…"
+    if [ "$2" = "nographic" ]; then
+      $QEMU -cdrom exocore.iso \
+           -boot order=d \
+           -serial stdio \
+           -monitor none \
+           -no-reboot \
+           -display none \
+           ${QEMU_EXTRA:+$QEMU_EXTRA}
+    else
+      $QEMU -cdrom exocore.iso \
+           -boot order=d \
+           -serial stdio \
+           -monitor none \
+           -no-reboot \
+           ${QEMU_EXTRA:+$QEMU_EXTRA}
+    fi
   else
-    $QEMU -cdrom exocore.iso \
-         -boot order=d \
-         -serial stdio \
-         -monitor none \
-         -no-reboot
+    echo "Done, use './build.sh run [nographic]' to build & boot"
   fi
-else
-  echo "Done, use './build.sh run [nographic]' to build & boot"
-fi
 


### PR DESCRIPTION
## Summary
- allow passing extra QEMU flags via `$QEMU_EXTRA`
- rebuild and boot kernel through `build.sh` in `full_kernel_test.sh`
- document new integration in release notes

## Testing
- `bash tests/test_mem.sh`
- `bash tests/full_kernel_test.sh` (times out after build and boot)

------
https://chatgpt.com/codex/tasks/task_e_6850df4c15dc8330a093d9929af3fa3a