### PR TITLE
Ensure modules load at fixed address

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -18,6 +18,7 @@
 - Static `io` helpers simplify port I/O access
 - Shared `panic` routine for consistent fatal error reporting
 - Build script supports multiple architectures and defaults to 64-bit
+- Module base address consolidated into `config.h` ensuring consistent loading
 - New `console_uhex` function for hexadecimal output
 - Kernel prints module addresses and entry points in hex
 - Modules build with `-m64` when using the x86_64 toolchain

--- a/build.sh
+++ b/build.sh
@@ -49,6 +49,9 @@ echo " 5) aarch64-linux-gnu (ARM64)"
 echo " 6) riscv64-unknown-elf (RISC-V)"
 read -p "Enter choice [1-6]: " arch_choice
 
+# Module load address must match MODULE_BASE_ADDR in include/config.h
+MODULE_BASE=0x00110000
+
 case "$arch_choice" in
   1)
     CC=gcc; LD=ld; ARCH_FLAG=-m64; LDARCH="elf_x86_64";
@@ -192,7 +195,7 @@ for src in run/*.c; do
         -Iinclude -c kernel/mem.c -o run/memtest_mem.o
     extra="run/memtest_mem.o"
   fi
-  $LD -m $LDARCH -Ttext 0x00110000 \
+  $LD -m $LDARCH -Ttext ${MODULE_BASE} \
       "$obj" run/console_mod.o run/serial_mod.o ${DEP_OBJS:+run/linkdep.a} $extra \
       -o "$elf"
 done
@@ -210,7 +213,7 @@ if [ -d run/userland ]; then
     $CC $MODULE_FLAG -std=gnu99 -ffreestanding -O2 -fcf-protection=none -nostdlib -nodefaultlibs \
         -Iinclude -c "$src" -o "$obj"
     echo "Linking $obj + console/serial stubs + linkdep.a → $elf"
-    $LD -m $LDARCH -Ttext 0x00110000 \
+    $LD -m $LDARCH -Ttext ${MODULE_BASE} \
         "$obj" run/console_mod.o run/serial_mod.o ${DEP_OBJS:+run/linkdep.a} \
         -o "$elf"
     USER_MODULES+=( "$elf" )

--- a/include/config.h
+++ b/include/config.h
@@ -4,4 +4,7 @@
 /* Enable run-directory modules */
 #define FEATURE_RUN_DIR 1
 
+/* Fixed load address for all modules */
+#define MODULE_BASE_ADDR 0x00110000
+
 #endif /* EXOCORE_CONFIG_H */

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -71,10 +71,10 @@ void kernel_main(uint32_t magic, multiboot_info_t *mbi) {
 
 #if FEATURE_RUN_DIR
     /* 5) Load & execute modules. Modules are linked to run at
-       * 0x110000, but GRUB may load them at arbitrary addresses.
+       * MODULE_BASE_ADDR, but GRUB may load them at arbitrary addresses.
        * Copy each module to the expected location before jumping. */
     multiboot_module_t *mods = (multiboot_module_t*)(uintptr_t)mbi->mods_addr;
-    uint8_t *const load_addr = (uint8_t*)0x110000;
+    uint8_t *const load_addr = (uint8_t*)MODULE_BASE_ADDR;
     for (uint32_t i = 0; i < mbi->mods_count; i++) {
         const char *mstr = (const char*)(uintptr_t)mods[i].string;
         int is_user = (mstr && !strncmp(mstr, "userland", 8));


### PR DESCRIPTION
## Summary
- consolidate module load address constant into `config.h`
- use the constant within `kernel/main.c` and `build.sh`
- document the change in release notes

## Testing
- `bash tests/test_mem.sh`
- `bash tests/full_kernel_test.sh` *(fails: qemu not present)*

------
https://chatgpt.com/codex/tasks/task_e_6850ea2fd5a083309b39c226a87556f4