### PR TITLE
Fix module load overlap

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -50,7 +50,7 @@ echo " 6) riscv64-unknown-elf (RISC-V)"
 read -p "Enter choice [1-6]: " arch_choice
 
 # Module load address must match MODULE_BASE_ADDR in include/config.h
-MODULE_BASE=0x00110000
+MODULE_BASE=0x00200000
 
 case "$arch_choice" in
   1)

--- a/include/config.h
+++ b/include/config.h
@@ -5,6 +5,6 @@
 #define FEATURE_RUN_DIR 1
 
 /* Fixed load address for all modules */
-#define MODULE_BASE_ADDR 0x00110000
+#define MODULE_BASE_ADDR 0x00200000
 
 #endif /* EXOCORE_CONFIG_H */


### PR DESCRIPTION
## Summary
- bump `MODULE_BASE_ADDR` in config to 0x00200000
- update build script to match new module base

## Testing
- `bash tests/test_mem.sh`
- `bash tests/full_kernel_test.sh` *(fails to show boot output)*

------
https://chatgpt.com/codex/tasks/task_e_6850fc6734408330a0077a1bd844f615