### PR TITLE
Fix memory tests by initializing heap in kernel tests

### DIFF
--- a/run/userland/02_kernel_tests.c
+++ b/run/userland/02_kernel_tests.c
@@ -14,6 +14,7 @@ extern uint32_t example_compute(uint32_t x, uint32_t y);
 
 static int pass = 0;
 static int fail = 0;
+static char heap[8192];
 
 static void result(const char *name, int ok) {
     if (ok) {
@@ -149,6 +150,7 @@ void _start() {
     set_color();
     console_puts("Welcome to ExoCore-OS v" OS_VERSION "! Powered by ExoCore-Kernel v" KERNEL_VERSION "!\n");
     serial_write("Starting kernel tests\n");
+    mem_init((uintptr_t)heap, sizeof(heap));
 
     test_pointer_size();
     test_example_compute();


### PR DESCRIPTION
## Summary
- init heap for kernel test userland module

## Testing
- `tests/full_kernel_test.sh` *(fails: qemu terminates)*

------
https://chatgpt.com/codex/tasks/task_e_685119da84a48330a39be3575c83e638