### PR TITLE
Fix mem_save_app unresolved memcpy

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -9,6 +9,7 @@
 - Headers now use `extern "C"` guards, preventing unresolved symbols when linking with C++
 - Fixed undefined references in `00_kernel_tester` by linking serial stubs and adding `strncmp`
 - Corrected ELF loader to handle 64-bit program headers, fixing invalid opcode crashes on boot
+- `mem_save_app` now copies data directly so modules build without `memutils`
 
 ## Improvements
 - Added priority-based ballooning allocator

--- a/kernel/mem.c
+++ b/kernel/mem.c
@@ -108,7 +108,10 @@ int mem_save_app(int app_id, const void *data, size_t size) {
             void *dst = mem_alloc_app(app_id, size);
             if (!dst)
                 return -1;
-            memcpy(dst, data, size);
+            const unsigned char *s = data;
+            unsigned char *d = dst;
+            for (size_t j = 0; j < size; j++)
+                d[j] = s[j];
             int idx = apps[i].block_count;
             apps[i].blocks[idx].addr = dst;
             apps[i].blocks[idx].size = size;


### PR DESCRIPTION
## Summary
- inline copy loop in `mem_save_app` to avoid unresolved `memcpy`
- document bug fix in release notes

## Testing
- `tests/test_mem.sh`
- `./build.sh` (option 3)

------
https://chatgpt.com/codex/tasks/task_e_68513c2c44cc833095e85acfcef8ccac