### PR TITLE
Add scroll buffer and rename OS

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -51,7 +51,7 @@
 
 ## New Features
 - Automatic "kernel tester" module validates 64-bit mode and library linkage
-- New GRUB entries: "ExoCore-Kernel (Debug)" enables verbose serial/VGA logs and "ExoCore-OS (alpha)" boots userland modules
+- New GRUB entries: "ExoCore-Kernel (Debug)" enables verbose serial/VGA logs and "ExoCore-Management-shell (alpha)" boots userland modules
 - Build script compiles userland modules and packages them separately
 - Improved full kernel test script integrates with build.sh for detailed logs
 - Boot-time kernel tests now print colored success/fail messages on VGA

--- a/build.sh
+++ b/build.sh
@@ -324,7 +324,7 @@ cat >> isodir/boot/grub/grub.cfg << EOF
   boot
 }
 
-menuentry "ExoCore-OS (alpha)" {
+menuentry "ExoCore-Management-shell (alpha)" {
   multiboot /boot/kernel.bin userland
 EOF
 for mod in "${USER_MODULES_BN[@]}"; do

--- a/include/console.h
+++ b/include/console.h
@@ -56,6 +56,12 @@ char console_getc(void);
 /** Set the current foreground/background attribute. */
 void console_set_attr(uint8_t fg, uint8_t bg);
 
+/** Scroll the visible console up by one line if possible */
+void console_scroll_up(void);
+
+/** Scroll the visible console down by one line if possible */
+void console_scroll_down(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/kernel/console.c
+++ b/kernel/console.c
@@ -2,31 +2,82 @@
 #include "console.h"
 
 static volatile char *video = (char*)0xB8000;
-static uint16_t cursor = 0;
 static uint8_t attr = VGA_ATTR(VGA_WHITE, VGA_BLACK);
 
-void console_init(void) {
-    for (uint32_t i = 0; i < 80*25; i++) {
-        video[i*2]   = ' ';
-        video[i*2+1] = attr;
-    }
-    cursor = 0;
+#define BUF_LINES 200
+static uint16_t buf[BUF_LINES][80];
+static uint32_t head = 0;      /* index of oldest line */
+static uint32_t count = 1;     /* number of lines stored (at least 1) */
+static uint32_t cur_line = 0;  /* current line index */
+static uint32_t cur_col = 0;
+static uint32_t view = 0;      /* top line offset from head */
+
+static uint16_t pack(char c) { return ((uint16_t)attr << 8) | (uint8_t)c; }
+
+static uint32_t idx(uint32_t off) { return (head + off) % BUF_LINES; }
+
+static void clear_line(uint32_t line) {
+    for (int i = 0; i < 80; i++)
+        buf[line][i] = pack(' ');
 }
 
-static void advance(void) {
-    cursor++;
-    if (cursor >= 80*25) cursor = 0;
+static void draw_screen(void) {
+    uint32_t start = (count > 25 && view + 25 > count) ? count - 25 : view;
+    if (count <= 25) start = 0;
+    for (int r = 0; r < 25; r++) {
+        uint32_t off = start + r;
+        if (off >= count) {
+            for (int c = 0; c < 80; c++) {
+                video[(r*80+c)*2] = ' ';
+                video[(r*80+c)*2+1] = attr;
+            }
+        } else {
+            uint16_t *line = buf[idx(off)];
+            for (int c = 0; c < 80; c++) {
+                uint16_t v = line[c];
+                video[(r*80+c)*2] = (char)v;
+                video[(r*80+c)*2+1] = v >> 8;
+            }
+        }
+    }
+}
+
+void console_init(void) {
+    for (uint32_t l = 0; l < BUF_LINES; l++)
+        clear_line(l);
+    head = 0;
+    count = 1;
+    cur_line = 0;
+    cur_col = 0;
+    view = 0;
+    draw_screen();
+}
+
+static void newline(void) {
+    for (uint32_t c = cur_col; c < 80; c++)
+        buf[cur_line][c] = pack(' ');
+    cur_col = 0;
+    cur_line = (cur_line + 1) % BUF_LINES;
+    if (count < BUF_LINES) {
+        count++;
+    } else {
+        head = (head + 1) % BUF_LINES;
+        if (view > 0) view--;
+    }
+    clear_line(cur_line);
 }
 
 void console_putc(char c) {
     if (c == '\n') {
-        cursor = (cursor/80 + 1) * 80;
-        if (cursor >= 80*25) cursor = 0;
+        newline();
     } else {
-        video[cursor*2]   = c;
-        video[cursor*2+1] = attr;
-        advance();
+        buf[cur_line][cur_col] = pack(c);
+        cur_col++;
+        if (cur_col >= 80)
+            newline();
     }
+    view = (count > 25) ? count - 25 : 0;
+    draw_screen();
 }
 
 void console_puts(const char *s) {
@@ -65,17 +116,34 @@ void console_set_attr(uint8_t fg, uint8_t bg) {
 }
 
 void console_backspace(void) {
-    if (cursor == 0)
+    if (cur_col == 0)
         return;
-    cursor--;
-    video[cursor*2] = ' ';
-    video[cursor*2+1] = attr;
+    cur_col--;
+    buf[cur_line][cur_col] = pack(' ');
+    draw_screen();
 }
 
 void console_clear(void) {
-    for (uint32_t i = 0; i < 80*25; i++) {
-        video[i*2] = ' ';
-        video[i*2+1] = attr;
+    for (uint32_t l = 0; l < BUF_LINES; l++)
+        clear_line(l);
+    head = 0;
+    count = 1;
+    cur_line = 0;
+    cur_col = 0;
+    view = 0;
+    draw_screen();
+}
+
+void console_scroll_up(void) {
+    if (view > 0) {
+        view--;
+        draw_screen();
     }
-    cursor = 0;
+}
+
+void console_scroll_down(void) {
+    if (view + 25 < count) {
+        view++;
+        draw_screen();
+    }
 }

--- a/kernel/console.h
+++ b/kernel/console.h
@@ -49,4 +49,10 @@ void console_clear(void);
 /* Set the current foreground/background attribute. */
 void console_set_attr(uint8_t fg, uint8_t bg);
 
+/* Scroll the visible console up by one line if possible */
+void console_scroll_up(void);
+
+/* Scroll the visible console down by one line if possible */
+void console_scroll_down(void);
+
 #endif /* CONSOLE_H */

--- a/linkdep/console_getc.c
+++ b/linkdep/console_getc.c
@@ -43,8 +43,12 @@ static char scancode_to_ascii(uint8_t sc) {
         case 0x39: return ' ';
         case 0x1C: return '\n';
         case 0x0E: return '\b';
-        case 0x48: return (char)0x80; /* up */
-        case 0x50: return (char)0x81; /* down */
+        case 0x48:
+            console_scroll_up();
+            return (char)0x80; /* up */
+        case 0x50:
+            console_scroll_down();
+            return (char)0x81; /* down */
         default:   return 0;
     }
 }

--- a/run/userland/02_kernel_tests.c
+++ b/run/userland/02_kernel_tests.c
@@ -148,7 +148,7 @@ static void test_io_ports(void) {
 
 void _start() {
     set_color();
-    console_puts("Welcome to ExoCore-OS v" OS_VERSION "! Powered by ExoCore-Kernel v" KERNEL_VERSION "!\n");
+    console_puts("Welcome to ExoCore-Management-shell (alpha) v" OS_VERSION "! Powered by ExoCore-Kernel v" KERNEL_VERSION "!\n");
     serial_write("Starting kernel tests\n");
     mem_init((uintptr_t)heap, sizeof(heap));
 


### PR DESCRIPTION
## Summary
- implement scrollback buffer with up/down key scrolling
- hook scroll controls into keyboard handler
- rebrand ExoCore-OS to ExoCore-Management-shell (alpha)

## Testing
- `bash tests/test_mem.sh`
- `bash tests/full_kernel_test.sh`

------
https://chatgpt.com/codex/tasks/task_e_685141437b6883309ef0b9bc633fb944