### PR TITLE
Improve shell help command and graphics test

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -63,4 +63,5 @@
 - Arrow key navigation in console_getc for command history
 - Memory manager now supports saving and retrieving per-app data
 - Shell commands added for saving strings and showing memory usage
+- Shell 'help' command replaces 'elp' and graphics test draws colored rectangles
 


### PR DESCRIPTION
## Summary
- enhance `gfx_test` to draw colored rectangles
- rename `elp` command to `help`
- store boot order strings safely
- document shell update in release notes

## Testing
- `echo 3 | ./build.sh`
- `tests/full_kernel_test.sh` *(fails: CPU reset output)*

------
https://chatgpt.com/codex/tasks/task_e_6851791170208330a60916a21953a8ce