### PR TITLE
Add text module interpreter

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 * ISO packaging via GRUB for easy QEMU testing
 * Example `simple-demo` app demonstrating keyboard input and output
 * Interrupt descriptor table with fault-driven panics
+* TinyScript interpreter allows text-based `.ts` modules
 
 ## Prerequisites
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -65,3 +65,4 @@
 - Shell commands added for saving strings and showing memory usage
 - Shell 'help' command replaces 'elp' and graphics test draws colored rectangles
 
+- Added TinyScript interpreter for text-based modules

--- a/build.sh
+++ b/build.sh
@@ -269,13 +269,15 @@ $CC $ARCH_FLAG -std=gnu99 -ffreestanding -O2 -fcf-protection=none -Wall -Iinclud
     -c kernel/panic.c   -o kernel/panic.o
 $CC $ARCH_FLAG -std=gnu99 -ffreestanding -O2 -fcf-protection=none -Wall -Iinclude \
     -c kernel/memutils.c -o kernel/memutils.o
+$CC $ARCH_FLAG -std=gnu99 -ffreestanding -O2 -fcf-protection=none -Wall -Iinclude \
+    -c kernel/script.c -o kernel/script.o
 
 # 9) Link into flat kernel.bin
 echo "Linking kernel.bin..."
 $LD -m $LDARCH -T linker.ld \
     arch/x86/boot.o arch/x86/idt.o \
     kernel/main.o kernel/mem.o kernel/console.o kernel/serial.o \
-    kernel/idt.o kernel/panic.o kernel/memutils.o \
+    kernel/idt.o kernel/panic.o kernel/memutils.o kernel/script.o \
     -o kernel.bin
 
 # 10) Prepare ISO tree
@@ -284,7 +286,7 @@ cp kernel.bin isodir/boot/
 
 # 11) Copy modules into ISO
 MODULES=()
-for m in run/*.{bin,elf}; do
+for m in run/*.{bin,elf,ts}; do
   [ -f "$m" ] || continue
   bn=$(basename "$m")
   cp "$m" isodir/boot/"$bn"

--- a/include/script.h
+++ b/include/script.h
@@ -1,0 +1,5 @@
+#ifndef EXOCORE_SCRIPT_H
+#define EXOCORE_SCRIPT_H
+#include <stddef.h>
+void run_script(const char *code, size_t size);
+#endif

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -11,6 +11,7 @@
 #include "idt.h"
 #include "serial.h"
 #include "runstate.h"
+#include "script.h"
 
 static int debug_mode = 0;
 static int userland_mode = 0;
@@ -87,6 +88,22 @@ void kernel_main(uint32_t magic, multiboot_info_t *mbi) {
         uint32_t size = mods[i].mod_end - mods[i].mod_start;
         memcpy(load_addr, src, size);
         uint8_t *base = load_addr;
+
+        /* check for TinyScript */
+        int is_ts = 0;
+        if (mstr) {
+            const char *p = mstr;
+            while (*p) p++;
+            if (p - mstr >= 3 && p[-3] == '.' && p[-2] == 't' && p[-1] == 's')
+                is_ts = 1;
+        }
+
+        if (is_ts) {
+            console_puts("  TinyScript module\n");
+            if (debug_mode) serial_write("  TinyScript module\n");
+            run_script((const char*)src, size);
+            continue;
+        }
 
         /* Debug header */
         console_puts("Module "); console_udec(i); console_puts("\n");

--- a/kernel/script.c
+++ b/kernel/script.c
@@ -1,0 +1,61 @@
+#include "script.h"
+#include "console.h"
+#include <stddef.h>
+
+static int str_equal(const char *a, const char *b) {
+    while (*a && *b && *a == *b) { a++; b++; }
+    return *a == '\0' && *b == '\0';
+}
+
+static int to_int(const char *s) {
+    int neg = 0; int v = 0;
+    if (*s == '-') { neg = 1; s++; }
+    while (*s >= '0' && *s <= '9') {
+        v = v * 10 + (*s - '0');
+        s++;
+    }
+    return neg ? -v : v;
+}
+
+void run_script(const char *code, size_t size) {
+    int stack[32];
+    int sp = 0;
+    char tok[32];
+    int tlen = 0;
+    for (size_t i = 0; i <= size; i++) {
+        char c = (i == size) ? ' ' : code[i];
+        if (c == ' ' || c == '\n' || c == '\t' || i == size) {
+            if (tlen == 0) continue;
+            tok[tlen] = '\0';
+
+            if ((tok[0] >= '0' && tok[0] <= '9') ||
+                (tok[0] == '-' && tok[1] && tok[1] >= '0' && tok[1] <= '9')) {
+                if (sp < 32) stack[sp++] = to_int(tok);
+            } else if (str_equal(tok, "+")) {
+                if (sp >= 2) { stack[sp-2] += stack[sp-1]; sp--; }
+            } else if (str_equal(tok, "-")) {
+                if (sp >= 2) { stack[sp-2] -= stack[sp-1]; sp--; }
+            } else if (str_equal(tok, "*")) {
+                if (sp >= 2) { stack[sp-2] *= stack[sp-1]; sp--; }
+            } else if (str_equal(tok, "/")) {
+                if (sp >= 2 && stack[sp-1] != 0) { stack[sp-2] /= stack[sp-1]; sp--; }
+            } else if (str_equal(tok, "print")) {
+                if (sp > 0) { console_udec((unsigned)stack[--sp]); console_putc('\n'); }
+            } else if (str_equal(tok, "char")) {
+                if (sp > 0) { console_putc((char)stack[--sp]); }
+            } else if (str_equal(tok, "dup")) {
+                if (sp > 0 && sp < 32) { stack[sp] = stack[sp-1]; sp++; }
+            } else if (str_equal(tok, "drop")) {
+                if (sp > 0) sp--;
+            } else if (str_equal(tok, "swap")) {
+                if (sp >= 2) { int t = stack[sp-1]; stack[sp-1] = stack[sp-2]; stack[sp-2] = t; }
+            } else if (str_equal(tok, "exit")) {
+                return;
+            }
+            tlen = 0;
+        } else {
+            if (tlen < 31) tok[tlen++] = c;
+        }
+    }
+}
+

--- a/run/example_script.ts
+++ b/run/example_script.ts
@@ -1,0 +1,4 @@
+# TinyScript example: prints sum of two numbers and a message
+2 3 + print
+72 char 101 char 108 char 108 char 111 char 10 char
+exit


### PR DESCRIPTION
## Summary
- introduce TinyScript interpreter
- detect `.ts` modules in the boot loader
- compile interpreter into the kernel
- document TinyScript modules
- update release notes
- include example script module

## Testing
- `./tests/test_mem.sh`
- `./tests/full_kernel_test.sh`

------
https://chatgpt.com/codex/tasks/task_e_68517aa209dc8330a0e15929a336f601