### PR TITLE
Add MicroPython runtime integration

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -66,3 +66,4 @@
 - Shell 'help' command replaces 'elp' and graphics test draws colored rectangles
 
 - Added TinyScript interpreter for text-based modules
+- MicroPython runtime integrated; '.py' modules now execute via embedded interpreter

--- a/include/micropython.h
+++ b/include/micropython.h
@@ -1,0 +1,5 @@
+#ifndef MICROPYTHON_H
+#define MICROPYTHON_H
+#include <stddef.h>
+void run_micropython(const char *code, size_t size);
+#endif

--- a/kernel/micropython.c
+++ b/kernel/micropython.c
@@ -1,0 +1,21 @@
+#include "micropython.h"
+#include "console.h"
+#include "mem.h"
+#include "port/micropython_embed.h"
+#include <string.h>
+
+static char mp_heap[64 * 1024];
+
+void run_micropython(const char *code, size_t size) {
+    int stack_top;
+    mp_embed_init(mp_heap, sizeof(mp_heap), &stack_top);
+    char *buf = mem_alloc(size + 1);
+    if (!buf) {
+        mp_embed_deinit();
+        return;
+    }
+    memcpy(buf, code, size);
+    buf[size] = '\0';
+    mp_embed_exec_str(buf);
+    mp_embed_deinit();
+}


### PR DESCRIPTION
## Summary
- integrate MicroPython embed port in build.sh
- add runtime support for `.py` modules in kernel
- include new `micropython.h` and implementation
- document MicroPython support in release notes

## Testing
- `tests/test_mem.sh`

------
https://chatgpt.com/codex/tasks/task_e_6852613e4ca48330b6761a76ebd94250