### PR TITLE
Add build check for micropython config

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -130,8 +130,14 @@ MP_DIR="micropython"
 if [ ! -d "$MP_DIR" ]; then
   git clone --depth 1 https://github.com/micropython/micropython.git "$MP_DIR"
 fi
+# Ensure the Micropython embed port is built
 if [ ! -d "$MP_DIR/examples/embedding/micropython_embed" ]; then
   make -C "$MP_DIR/examples/embedding" -f micropython_embed.mk
+fi
+if [ ! -f "$MP_DIR/examples/embedding/mpconfigport.h" ]; then
+  echo "Error: mpconfigport.h not found in $MP_DIR/examples/embedding" >&2
+  echo "Micropython fetch or build failed" >&2
+  exit 1
 fi
 # patch stdout handler to use kernel console
 cat > "$MP_DIR/examples/embedding/micropython_embed/port/mphalport.c" <<'EOF'


### PR DESCRIPTION
## Summary
- ensure `mpconfigport.h` exists when fetching micropython

## Testing
- `tests/test_mem.sh`
- `tests/full_kernel_test.sh` *(fails: head cannot open tests/full_test_cpu.log)*


------
https://chatgpt.com/codex/tasks/task_e_68526c7b9cdc8330b0c5d82866e2cbe7