### PR TITLE
Adjust module loop for python

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -328,7 +328,7 @@ cp kernel.bin isodir/boot/
 
 # 11) Copy modules into ISO
 MODULES=()
-for m in run/*.{bin,elf,ts}; do
+for m in run/*.{bin,elf,ts,py}; do
   [ -f "$m" ] || continue
   bn=$(basename "$m")
   cp "$m" isodir/boot/"$bn"


### PR DESCRIPTION
## Summary
- include `.py` files when copying modules for the ISO

## Testing
- `./tests/test_mem.sh`
- `./tests/full_kernel_test.sh` *(fails: `head: cannot open 'tests/full_test_cpu.log'`)*

------
https://chatgpt.com/codex/tasks/task_e_68526ff795248330956303b4c2d7b1d2