### PR TITLE
Enable mpy module support

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -32,7 +32,7 @@
 - Interrupt descriptor table with basic IRQ handling
 - Kernel boots directly into 64-bit long mode
 - Modules can be raw binaries or ELF executables
-- Kernel now skips non-ELF modules to avoid jumping into invalid binaries
+- Non-ELF modules now execute via MicroPython instead of being skipped
 
 ## Minor Fixes
 - Resolved pointer-size warnings in module loader
@@ -67,6 +67,7 @@
 
 - Added TinyScript interpreter for text-based modules
 - MicroPython runtime integrated; '.py' modules now execute via embedded interpreter
+- Compiled '.mpy' files are packaged in the ISO and loaded instead of '.py'
 
 ## Bug Fixes
 - Fixed MicroPython build errors by adding missing include path and implementing libc stubs.

--- a/include/micropython.h
+++ b/include/micropython.h
@@ -1,5 +1,7 @@
 #ifndef MICROPYTHON_H
 #define MICROPYTHON_H
 #include <stddef.h>
+#include <stdint.h>
 void run_micropython(const char *code, size_t size);
+void run_micropython_mpy(const uint8_t *buf, size_t size);
 #endif

--- a/kernel/micropython.c
+++ b/kernel/micropython.c
@@ -19,3 +19,10 @@ void run_micropython(const char *code, size_t size) {
     mp_embed_exec_str(buf);
     mp_embed_deinit();
 }
+
+void run_micropython_mpy(const uint8_t *buf, size_t size) {
+    int stack_top;
+    mp_embed_init(mp_heap, sizeof(mp_heap), &stack_top);
+    mp_embed_exec_mpy(buf, size);
+    mp_embed_deinit();
+}


### PR DESCRIPTION
## Summary
- compile Python sources with `mpy-cross`
- include `.mpy` modules in the ISO
- run `.mpy` and other non-ELF modules via MicroPython
- document support for `.mpy` modules

## Testing
- `./tests/test_mem.sh`
- `./tests/full_kernel_test.sh` *(fails: interactive build)*

------
https://chatgpt.com/codex/tasks/task_e_6852748d7f4c83308db48afdd0991f72