### PR TITLE
Fix micropython build config and warning

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -139,6 +139,10 @@ if [ ! -f "$MP_DIR/examples/embedding/mpconfigport.h" ]; then
   echo "Micropython fetch or build failed" >&2
   exit 1
 fi
+# Ensure persistent .mpy loading is enabled
+if ! grep -q "MICROPY_PERSISTENT_CODE_LOAD" "$MP_DIR/examples/embedding/mpconfigport.h"; then
+  echo "#define MICROPY_PERSISTENT_CODE_LOAD (1)" >> "$MP_DIR/examples/embedding/mpconfigport.h"
+fi
 # patch stdout handler to use kernel console
 cat > "$MP_DIR/examples/embedding/micropython_embed/port/mphalport.c" <<'EOF'
 #include "console.h"

--- a/kernel/idt.c
+++ b/kernel/idt.c
@@ -125,11 +125,11 @@ void idt_handle_interrupt(uint32_t num, uint32_t err, uint64_t rsp) {
             const char *type = current_user_app ? "User app" : "Kernel process";
             console_puts(type);
             console_puts(" crashed: ");
-            console_puts(current_program);
+            console_puts((const char *)current_program);
             console_putc('\n');
             serial_write(type);
             serial_write(" crashed: ");
-            serial_write(current_program);
+            serial_write((const char *)current_program);
             serial_write("\n");
             panic("Fatal exception");
         }


### PR DESCRIPTION
## Summary
- set MICROPY_PERSISTENT_CODE_LOAD automatically when building Micropython
- cast `current_program` in interrupt handler to silence volatile warnings

## Testing
- `tests/test_mem.sh`
- `./build.sh <<'EOF'
3
EOF` *(builds Micropython and kernel)*

------
https://chatgpt.com/codex/tasks/task_e_6852788af8588330a9049eb7b0e3df22