### PR TITLE
Fix MicroPython cross path

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -278,7 +278,7 @@ for asm in run/*.asm; do
 done
 
 # Compile Python modules to .mpy
-MPYCROSS="$MP_DIR/mpy-cross/mpy-cross"
+MPYCROSS="$MP_DIR/mpy-cross/build/mpy-cross"
 if [ ! -x "$MPYCROSS" ]; then
   make -C "$MP_DIR/mpy-cross"
 fi


### PR DESCRIPTION
## Summary
- fix build script path to `mpy-cross` executable

## Testing
- `bash tests/test_mem.sh`

------
https://chatgpt.com/codex/tasks/task_e_685281baf0a88330b52967e56220f059