### PR TITLE
Fix MicroPython stack alignment crash

### DIFF
--- a/include/micropython.h
+++ b/include/micropython.h
@@ -2,6 +2,9 @@
 #define MICROPYTHON_H
 #include <stddef.h>
 #include <stdint.h>
-void run_micropython(const char *code, size_t size);
-void run_micropython_mpy(const uint8_t *buf, size_t size);
+// Ensure these functions are entered with a 16-byte aligned stack
+void run_micropython(const char *code, size_t size)
+    __attribute__((force_align_arg_pointer));
+void run_micropython_mpy(const uint8_t *buf, size_t size)
+    __attribute__((force_align_arg_pointer));
 #endif

--- a/kernel/micropython.c
+++ b/kernel/micropython.c
@@ -6,6 +6,7 @@
 
 static char mp_heap[64 * 1024];
 
+__attribute__((force_align_arg_pointer))
 void run_micropython(const char *code, size_t size) {
     int stack_top;
     mp_embed_init(mp_heap, sizeof(mp_heap), &stack_top);
@@ -19,6 +20,7 @@ void run_micropython(const char *code, size_t size) {
     mp_embed_exec_str(buf);
     mp_embed_deinit();
 }
+__attribute__((force_align_arg_pointer))
 
 void run_micropython_mpy(const uint8_t *buf, size_t size) {
     int stack_top;


### PR DESCRIPTION
## Summary
- align stack for MicroPython embed functions

## Testing
- `./build.sh run nographic`

------
https://chatgpt.com/codex/tasks/task_e_6852851b1e7c833095719e03dc4c01b3