### PR TITLE
Fix module loader to skip non-python non-ELF files

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -71,3 +71,4 @@
 
 ## Bug Fixes
 - Fixed MicroPython build errors by adding missing include path and implementing libc stubs.
+- Non-ELF modules without .py or .mpy extensions are skipped instead of executing via MicroPython.

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -130,11 +130,10 @@ void kernel_main(uint32_t magic, multiboot_info_t *mbi) {
         console_puts("Module "); console_udec(i); console_puts("\n");
         if (debug_mode) { serial_write("Module "); serial_udec(i); serial_write("\n"); }
 
-        /* Run unknown non-ELF modules via MicroPython */
+        /* Skip unknown non-ELF modules */
         if (*(uint32_t*)base != ELF_MAGIC) {
-            console_puts("  Non-ELF module via MicroPython\n");
-            if (debug_mode) serial_write("  Non-ELF module via MicroPython\n");
-            run_micropython((const char*)src, size);
+            console_puts("  Non-ELF module skipped\n");
+            if (debug_mode) serial_write("  Non-ELF module skipped\n");
             continue;
         }
 


### PR DESCRIPTION
## Summary
- skip non-ELF modules unless they end with `.py` or `.mpy`
- document the change in release notes

## Testing
- `./tests/test_mem.sh`
- `./tests/full_kernel_test.sh` *(fails: missing CPU log)*

------
https://chatgpt.com/codex/tasks/task_e_6852897f10008330b48384bd55e89faf