### PR TITLE
Fix Python module detection

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -68,7 +68,10 @@
 - Added TinyScript interpreter for text-based modules
 - MicroPython runtime integrated; '.py' modules now execute via embedded interpreter
 - Compiled '.mpy' files are packaged in the ISO and loaded instead of '.py'
+- Added `run/micropython_test.py` example to verify MicroPython script loading
 
 ## Bug Fixes
 - Fixed MicroPython build errors by adding missing include path and implementing libc stubs.
 - Non-ELF modules without .py or .mpy extensions are skipped instead of executing via MicroPython.
+- Python module extension matching is now case-insensitive so files like `.PY` and `.MPY` load correctly.
+- Loader now detects script extensions using a simplified lowercase comparison to avoid skipping valid TinyScript or MicroPython modules.

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -95,14 +95,22 @@ void kernel_main(uint32_t magic, multiboot_info_t *mbi) {
         int is_py = 0;
         int is_mpy = 0;
         if (mstr) {
-            const char *p = mstr;
-            while (*p) p++;
-            if (p - mstr >= 3 && p[-3] == '.' && p[-2] == 't' && p[-1] == 's')
-                is_ts = 1;
-            if (p - mstr >= 3 && p[-3] == '.' && p[-2] == 'p' && p[-1] == 'y')
-                is_py = 1;
-            if (p - mstr >= 4 && p[-4] == '.' && p[-3] == 'm' && p[-2] == 'p' && p[-1] == 'y')
+            const char *p = mstr; while (*p) p++;
+            int len = p - mstr;
+            #define LOWER(c) ((c) >= 'A' && (c) <= 'Z' ? (c) + 'a' - 'A' : (c))
+            if (len >= 3) {
+                if (LOWER(mstr[len-3]) == '.' && LOWER(mstr[len-2]) == 't' && LOWER(mstr[len-1]) == 's')
+                    is_ts = 1;
+                if (LOWER(mstr[len-3]) == '.' && LOWER(mstr[len-2]) == 'p' && LOWER(mstr[len-1]) == 'y')
+                    is_py = 1;
+            }
+            if (len >= 4 &&
+                LOWER(mstr[len-4]) == '.' &&
+                LOWER(mstr[len-3]) == 'm' &&
+                LOWER(mstr[len-2]) == 'p' &&
+                LOWER(mstr[len-1]) == 'y')
                 is_mpy = 1;
+            #undef LOWER
         }
 
         if (is_ts) {

--- a/run/micropython_test.py
+++ b/run/micropython_test.py
@@ -1,0 +1,1 @@
+print("MicroPython test executed")


### PR DESCRIPTION
## Summary
- recognize `.PY` and `.MPY` files
- document extension case fix
- add a MicroPython sample module
- improve loader's lowercase comparison for extensions

## Testing
- `tests/test_mem.sh`
- `tests/full_kernel_test.sh` *(fails: CPU Reset)*

------
https://chatgpt.com/codex/tasks/task_e_6852929e3f808330b92f70d1a560769f