### PR TITLE
Fix module loader parsing bug

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -77,3 +77,4 @@
 
 - Loader now detects script extensions using a simplified lowercase comparison to avoid skipping valid TinyScript or MicroPython modules.
 
+- Fixed unmatched closing brace in kernel module loader

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -111,7 +111,6 @@ void kernel_main(uint32_t magic, multiboot_info_t *mbi) {
                 LOWER(mstr[len-1]) == 'y')
                 is_mpy = 1;
             #undef LOWER
-         }
         }
 
         if (is_ts) {


### PR DESCRIPTION
## Summary
- fix stray brace in kernel main
- document the loader fix

## Testing
- `tests/test_mem.sh`
- `printf '1\n' | ./build.sh run nographic`

------
https://chatgpt.com/codex/tasks/task_e_6852a1a958608330ade5e4513f2ee740