### PR TITLE
Fix Python module loader for userland modules

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -78,3 +78,5 @@
 - Loader now detects script extensions using a simplified lowercase comparison to avoid skipping valid TinyScript or MicroPython modules.
 
 - Fixed unmatched closing brace in kernel module loader
+- Userland Python modules now include the file path in the module string so the
+  loader detects '.py' and '.mpy' correctly

--- a/build.sh
+++ b/build.sh
@@ -393,7 +393,7 @@ menuentry "ExoCore-Management-shell (alpha)" {
   multiboot /boot/kernel.bin userland
 EOF
 for mod in "${USER_MODULES_BN[@]}"; do
-  echo "  module /boot/$mod userland" >> isodir/boot/grub/grub.cfg
+  echo "  module /boot/$mod userland /boot/$mod" >> isodir/boot/grub/grub.cfg
 done
 cat >> isodir/boot/grub/grub.cfg << EOF
   boot


### PR DESCRIPTION
## Summary
- ensure userland modules pass their file paths in grub.cfg so loader can check extensions
- note Python loader fix in release notes

## Testing
- `./tests/full_kernel_test.sh` *(fails: TEST FAILED)*
- `./tests/test_mem.sh`


------
https://chatgpt.com/codex/tasks/task_e_6852a6e5015c833083bece18542355e0