### PR TITLE
Add ATA PIO storage driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@
 * Example `simple-demo` app demonstrating keyboard input and output
 * Interrupt descriptor table with fault-driven panics
 * TinyScript interpreter allows text-based `.ts` modules
+* Simple memory-backed filesystem driver that can mount, read, and write storage
+* Basic ATA PIO driver for block storage access
 
 ## Prerequisites
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -80,3 +80,9 @@
 - Fixed unmatched closing brace in kernel module loader
 - Userland Python modules now include the file path in the module string so the
   loader detects '.py' and '.mpy' correctly
+
+## New Features
+- Memory-backed filesystem driver that can mount a storage region
+  and read or write arbitrary bytes.
+- Host test script `test_fs.sh` ensures driver functionality.
+- Basic ATA PIO block device driver for reading and writing disk sectors.

--- a/include/ata_pio.h
+++ b/include/ata_pio.h
@@ -1,0 +1,19 @@
+#ifndef ATA_PIO_H
+#define ATA_PIO_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void ata_pio_init(void);
+int ata_pio_read(uint32_t lba, void *buf, size_t count);
+int ata_pio_write(uint32_t lba, const void *buf, size_t count);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ATA_PIO_H */

--- a/include/fs.h
+++ b/include/fs.h
@@ -1,0 +1,24 @@
+#ifndef FS_H
+#define FS_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Mount a contiguous memory region as the storage backing. */
+void fs_mount(void *storage, size_t size);
+
+/* Read up to 'len' bytes from 'offset'. Returns bytes read. */
+size_t fs_read(size_t offset, void *buf, size_t len);
+
+/* Write up to 'len' bytes to 'offset'. Returns bytes written. */
+size_t fs_write(size_t offset, const void *data, size_t len);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* FS_H */

--- a/include/io.h
+++ b/include/io.h
@@ -8,6 +8,10 @@ extern "C" {
 
 void io_outb(uint16_t port, uint8_t val);
 uint8_t io_inb(uint16_t port);
+void io_outw(uint16_t port, uint16_t val);
+uint16_t io_inw(uint16_t port);
+void io_outl(uint16_t port, uint32_t val);
+uint32_t io_inl(uint16_t port);
 void io_wait(void);
 
 #ifdef __cplusplus

--- a/kernel/fs.c
+++ b/kernel/fs.c
@@ -1,0 +1,28 @@
+#include "fs.h"
+#include "memutils.h"
+
+static unsigned char *fs_data = NULL;
+static size_t fs_size = 0;
+
+void fs_mount(void *storage, size_t size) {
+    fs_data = (unsigned char *)storage;
+    fs_size = size;
+}
+
+size_t fs_read(size_t offset, void *buf, size_t len) {
+    if (!fs_data || offset >= fs_size)
+        return 0;
+    if (offset + len > fs_size)
+        len = fs_size - offset;
+    memcpy(buf, fs_data + offset, len);
+    return len;
+}
+
+size_t fs_write(size_t offset, const void *data, size_t len) {
+    if (!fs_data || offset >= fs_size)
+        return 0;
+    if (offset + len > fs_size)
+        len = fs_size - offset;
+    memcpy(fs_data + offset, data, len);
+    return len;
+}

--- a/linkdep/ata_pio.c
+++ b/linkdep/ata_pio.c
@@ -1,0 +1,60 @@
+#include "../include/ata_pio.h"
+#include "../include/io.h"
+
+#define ATA_IO_BASE 0x1F0
+#define ATA_CTRL_BASE 0x3F6
+
+static void ata_wait_bsy(void) {
+    while (io_inb(ATA_IO_BASE + 7) & 0x80) {
+    }
+}
+
+static void ata_wait_drq(void) {
+    while (!(io_inb(ATA_IO_BASE + 7) & 0x08)) {
+    }
+}
+
+void ata_pio_init(void) {
+    /* Disable IRQs */
+    io_outb(ATA_CTRL_BASE, 0x02);
+}
+
+int ata_pio_read(uint32_t lba, void *buf, size_t count) {
+    uint16_t *buffer = (uint16_t *)buf;
+    for (size_t i = 0; i < count; ++i) {
+        ata_wait_bsy();
+        io_outb(ATA_IO_BASE + 6, 0xE0 | ((lba >> 24) & 0x0F));
+        io_outb(ATA_IO_BASE + 2, 1);
+        io_outb(ATA_IO_BASE + 3, (uint8_t)lba);
+        io_outb(ATA_IO_BASE + 4, (uint8_t)(lba >> 8));
+        io_outb(ATA_IO_BASE + 5, (uint8_t)(lba >> 16));
+        io_outb(ATA_IO_BASE + 7, 0x20);
+        ata_wait_bsy();
+        ata_wait_drq();
+        for (int w = 0; w < 256; ++w)
+            buffer[w] = io_inw(ATA_IO_BASE);
+        buffer += 256;
+        ++lba;
+    }
+    return 0;
+}
+
+int ata_pio_write(uint32_t lba, const void *buf, size_t count) {
+    const uint16_t *buffer = (const uint16_t *)buf;
+    for (size_t i = 0; i < count; ++i) {
+        ata_wait_bsy();
+        io_outb(ATA_IO_BASE + 6, 0xE0 | ((lba >> 24) & 0x0F));
+        io_outb(ATA_IO_BASE + 2, 1);
+        io_outb(ATA_IO_BASE + 3, (uint8_t)lba);
+        io_outb(ATA_IO_BASE + 4, (uint8_t)(lba >> 8));
+        io_outb(ATA_IO_BASE + 5, (uint8_t)(lba >> 16));
+        io_outb(ATA_IO_BASE + 7, 0x30);
+        ata_wait_bsy();
+        ata_wait_drq();
+        for (int w = 0; w < 256; ++w)
+            io_outw(ATA_IO_BASE, buffer[w]);
+        buffer += 256;
+        ++lba;
+    }
+    return 0;
+}

--- a/linkdep/io.c
+++ b/linkdep/io.c
@@ -10,6 +10,26 @@ uint8_t io_inb(uint16_t port) {
     return ret;
 }
 
+void io_outw(uint16_t port, uint16_t val) {
+    __asm__ volatile ("outw %0, %1" : : "a"(val), "Nd"(port));
+}
+
+uint16_t io_inw(uint16_t port) {
+    uint16_t ret;
+    __asm__ volatile ("inw %1, %0" : "=a"(ret) : "Nd"(port));
+    return ret;
+}
+
+void io_outl(uint16_t port, uint32_t val) {
+    __asm__ volatile ("outl %0, %1" : : "a"(val), "Nd"(port));
+}
+
+uint32_t io_inl(uint16_t port) {
+    uint32_t ret;
+    __asm__ volatile ("inl %1, %0" : "=a"(ret) : "Nd"(port));
+    return ret;
+}
+
 void io_wait(void) {
     __asm__ volatile ("outb %%al, $0x80" : : "a"(0));
 }

--- a/tests/fs_test.c
+++ b/tests/fs_test.c
@@ -1,0 +1,14 @@
+#include <stdio.h>
+#include "../include/fs.h"
+
+int main() {
+    unsigned char buf[128];
+    fs_mount(buf, sizeof(buf));
+    const char msg[] = "hello";
+    if (fs_write(0, msg, sizeof(msg)) != sizeof(msg)) return 1;
+    char tmp[16];
+    if (fs_read(0, tmp, sizeof(msg)) != sizeof(msg)) return 1;
+    if (__builtin_memcmp(msg, tmp, sizeof(msg)) != 0) return 1;
+    printf("fs driver ok\n");
+    return 0;
+}

--- a/tests/test_ata_compile.sh
+++ b/tests/test_ata_compile.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -e
+BG_BLACK="\033[40m"
+FG_WHITE="\033[97m"
+FG_GREEN="\033[32m"
+FG_RED="\033[31m"
+RESET="\033[0m"
+
+DIR=$(dirname "$0")
+
+# Compile ATA driver to ensure it builds on host
+gcc -std=gnu99 -I"$DIR/../include" -c "$DIR/../linkdep/ata_pio.c" -o "$DIR/ata_pio.o"
+gcc -std=gnu99 -I"$DIR/../include" -c "$DIR/../linkdep/io.c" -o "$DIR/io.o"
+
+echo -e "${BG_BLACK}${FG_GREEN}ATA driver compiled successfully${RESET}"

--- a/tests/test_fs.sh
+++ b/tests/test_fs.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -e
+BG_BLACK="\033[40m"
+FG_WHITE="\033[97m"
+FG_GREEN="\033[32m"
+FG_RED="\033[31m"
+RESET="\033[0m"
+
+DIR=$(dirname "$0")
+
+echo -e "${BG_BLACK}${FG_WHITE}Building fs test...${RESET}"
+
+gcc -std=gnu99 -I"$DIR/../include" "$DIR/../kernel/fs.c" "$DIR/../kernel/memutils.c" "$DIR/fs_test.c" -o "$DIR/fs_test"
+
+if "$DIR/fs_test"; then
+  echo -e "${BG_BLACK}${FG_GREEN}FS test passed${RESET}"
+else
+  echo -e "${BG_BLACK}${FG_RED}FS test failed${RESET}"
+fi


### PR DESCRIPTION
## Summary
- extend `io` library with word and dword I/O helpers
- implement an ATA PIO driver in `linkdep` for block storage access
- add a compile test for the new driver
- document ATA driver in README and release notes

## Testing
- `tests/test_mem.sh`
- `tests/test_fs.sh`
- `tests/test_ata_compile.sh`


------
https://chatgpt.com/codex/tasks/task_e_6852aee18fd48330b1a0367abc265adc