### PR TITLE
Add memory backed filesystem driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 * Example `simple-demo` app demonstrating keyboard input and output
 * Interrupt descriptor table with fault-driven panics
 * TinyScript interpreter allows text-based `.ts` modules
+* Generic filesystem driver with read/write callbacks supporting any storage device
 
 ## Prerequisites
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -80,3 +80,8 @@
 - Fixed unmatched closing brace in kernel module loader
 - Userland Python modules now include the file path in the module string so the
   loader detects '.py' and '.mpy' correctly
+
+## New Features
+- Filesystem driver abstracts storage devices using read/write callbacks, allowing
+  mounting of any block device.
+- Host test script `test_fs.sh` ensures driver functionality.

--- a/include/fs.h
+++ b/include/fs.h
@@ -1,0 +1,30 @@
+#ifndef FS_H
+#define FS_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+    size_t size; /* total bytes available */
+    size_t (*read)(size_t offset, void *buf, size_t len);
+    size_t (*write)(size_t offset, const void *data, size_t len);
+} fs_device_t;
+
+/* Mount a generic storage device */
+void fs_mount(fs_device_t *dev);
+
+/* Read up to 'len' bytes from 'offset'. Returns bytes read. */
+size_t fs_read(size_t offset, void *buf, size_t len);
+
+/* Write up to 'len' bytes to 'offset'. Returns bytes written. */
+size_t fs_write(size_t offset, const void *data, size_t len);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* FS_H */

--- a/kernel/fs.c
+++ b/kernel/fs.c
@@ -1,0 +1,27 @@
+#include "fs.h"
+
+static fs_device_t *fs_dev = NULL;
+
+void fs_mount(fs_device_t *dev) {
+    fs_dev = dev;
+}
+
+size_t fs_read(size_t offset, void *buf, size_t len) {
+    if (!fs_dev || !fs_dev->read)
+        return 0;
+    if (offset >= fs_dev->size)
+        return 0;
+    if (offset + len > fs_dev->size)
+        len = fs_dev->size - offset;
+    return fs_dev->read(offset, buf, len);
+}
+
+size_t fs_write(size_t offset, const void *data, size_t len) {
+    if (!fs_dev || !fs_dev->write)
+        return 0;
+    if (offset >= fs_dev->size)
+        return 0;
+    if (offset + len > fs_dev->size)
+        len = fs_dev->size - offset;
+    return fs_dev->write(offset, data, len);
+}

--- a/tests/fs_test.c
+++ b/tests/fs_test.c
@@ -1,0 +1,28 @@
+#include <stdio.h>
+#include "../include/fs.h"
+#include "../include/memutils.h"
+
+#define STORAGE_SIZE 128
+static unsigned char storage[STORAGE_SIZE];
+
+static size_t mem_read(size_t offset, void *buf, size_t len) {
+    memcpy(buf, storage + offset, len);
+    return len;
+}
+
+static size_t mem_write(size_t offset, const void *data, size_t len) {
+    memcpy(storage + offset, data, len);
+    return len;
+}
+
+int main() {
+    fs_device_t dev = {STORAGE_SIZE, mem_read, mem_write};
+    fs_mount(&dev);
+    const char msg[] = "hello";
+    if (fs_write(0, msg, sizeof(msg)) != sizeof(msg)) return 1;
+    char tmp[16];
+    if (fs_read(0, tmp, sizeof(msg)) != sizeof(msg)) return 1;
+    if (memcmp(msg, tmp, sizeof(msg)) != 0) return 1;
+    printf("fs driver ok\n");
+    return 0;
+}

--- a/tests/test_fs.sh
+++ b/tests/test_fs.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -e
+BG_BLACK="\033[40m"
+FG_WHITE="\033[97m"
+FG_GREEN="\033[32m"
+FG_RED="\033[31m"
+RESET="\033[0m"
+
+DIR=$(dirname "$0")
+
+echo -e "${BG_BLACK}${FG_WHITE}Building fs test...${RESET}"
+
+gcc -std=gnu99 -I"$DIR/../include" "$DIR/../kernel/fs.c" "$DIR/../kernel/memutils.c" "$DIR/fs_test.c" -o "$DIR/fs_test"
+
+if "$DIR/fs_test"; then
+  echo -e "${BG_BLACK}${FG_GREEN}FS test passed${RESET}"
+else
+  echo -e "${BG_BLACK}${FG_RED}FS test failed${RESET}"
+fi


### PR DESCRIPTION
## Summary
- add a simple RAM backed filesystem driver with mount/read/write
- include host test for the driver
- document the new feature in README and release notes

## Testing
- `tests/test_fs.sh`
- `tests/test_mem.sh`


------
https://chatgpt.com/codex/tasks/task_e_6852aee18fd48330b1a0367abc265adc