### PR TITLE
Fix micropython module handling and stub debug logging

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -201,11 +201,11 @@ shopt -u nullglob
 mkdir -p run
 echo "Building console stub → run/console_mod.o"
 $CC $MODULE_FLAG -std=gnu99 -ffreestanding -O2 -fcf-protection=none -Wall \
-    -Iinclude \
+    -DNO_DEBUGLOG -Iinclude \
     -c kernel/console.c -o run/console_mod.o
 echo "Building serial stub → run/serial_mod.o"
 $CC $MODULE_FLAG -std=gnu99 -ffreestanding -O2 -fcf-protection=none -Wall \
-    -Iinclude \
+    -DNO_DEBUGLOG -Iinclude \
     -c kernel/serial.c -o run/serial_mod.o
 
 # 6) Compile & link each run/*.c → .elf

--- a/include/idt.h
+++ b/include/idt.h
@@ -2,6 +2,7 @@
 #define IDT_H
 
 #include <stdint.h>
+#include <stddef.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/kernel/console.c
+++ b/kernel/console.c
@@ -52,7 +52,9 @@ void console_init(void) {
     cur_col = 0;
     view = 0;
     draw_screen();
+#ifndef NO_DEBUGLOG
     debuglog_print_timestamp();
+#endif
     console_puts("console_init complete\n");
 }
 
@@ -79,7 +81,9 @@ void console_putc(char c) {
         if (cur_col >= 80)
             newline();
     }
+#ifndef NO_DEBUGLOG
     debuglog_char(c);
+#endif
     view = (count > 25) ? count - 25 : 0;
     draw_screen();
 }

--- a/kernel/idt.c
+++ b/kernel/idt.c
@@ -3,6 +3,7 @@
 #include "panic.h"
 #include "serial.h"
 #include "runstate.h"
+#include <stddef.h>
 
 extern void idt_load(idt_ptr_t *);
 extern void *isr_stub_table[];

--- a/kernel/serial.c
+++ b/kernel/serial.c
@@ -19,14 +19,18 @@ void serial_init(void) {
     outb(0x3F8 + 3, 0x03);
     outb(0x3F8 + 2, 0xC7);
     outb(0x3F8 + 4, 0x0B);
+#ifndef NO_DEBUGLOG
     debuglog_print_timestamp();
+#endif
     serial_write("serial_init complete\n");
 }
 
 void serial_putc(char c) {
     while (!(inb(0x3F8 + 5) & 0x20)) {}
     outb(0x3F8, c);
+#ifndef NO_DEBUGLOG
     debuglog_char(c);
+#endif
 }
 
 void serial_write(const char *s) {


### PR DESCRIPTION
## Summary
- handle micropython console/serial stubs without debug logging
- include `<stddef.h>` in idt declarations

## Testing
- `tests/full_kernel_test.sh`
- `tests/test_fatfs_compile.sh`
- `tests/test_ata_compile.sh`


------
https://chatgpt.com/codex/tasks/task_e_685d382a3e348330b27643b1f8c88116