### PR TITLE
Fix build script debuglog compile and link fs

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,7 @@
 ## Bug Fixes
 - Multiboot header now resides in the first load segment so GRUB can detect the kernel
 - Corrected typo in `build.sh` that prevented kernel compilation
+- Added missing backslash for `debuglog.c` compile and linked `fs.c` so debug logging builds cleanly
 - Fixed page table setup in `boot.S` so CR3 is loaded with the page directory base, preventing early triple faults
 - Corrected stack pointer initialization in `boot.S` which caused a page fault and system reset
 - Fixed invalid `lea` operand syntax in `boot.S` that broke the 64-bit stack setup

--- a/build.sh
+++ b/build.sh
@@ -332,8 +332,10 @@ $CC $ARCH_FLAG -std=gnu99 -ffreestanding -O2 -fcf-protection=none -Wall -Iinclud
 $CC $ARCH_FLAG -std=gnu99 -ffreestanding -O2 -fcf-protection=none -Wall -Iinclude \
     -c kernel/memutils.c -o kernel/memutils.o
 $CC $ARCH_FLAG -std=gnu99 -ffreestanding -O2 -fcf-protection=none -Wall -Iinclude \
+    -c kernel/fs.c -o kernel/fs.o
+$CC $ARCH_FLAG -std=gnu99 -ffreestanding -O2 -fcf-protection=none -Wall -Iinclude \
     -c kernel/script.c -o kernel/script.o
-$CC $ARCH_FLAG -std=gnu99 -ffreestanding -O2 -fcf-protection=none -Wall -Iinclude 
+$CC $ARCH_FLAG -std=gnu99 -ffreestanding -O2 -fcf-protection=none -Wall -Iinclude \
     -c kernel/debuglog.c -o kernel/debuglog.o
 
 # 9) Link into flat kernel.bin
@@ -341,7 +343,7 @@ echo "Linking kernel.bin..."
 $LD -m $LDARCH -T linker.ld \
     arch/x86/boot.o arch/x86/idt.o \
     kernel/main.o kernel/mem.o kernel/console.o kernel/serial.o \
-    kernel/idt.o kernel/panic.o kernel/memutils.o kernel/script.o \
+    kernel/idt.o kernel/panic.o kernel/memutils.o kernel/fs.o kernel/script.o \
     kernel/debuglog.o \
     kernel/micropython.o ${MP_OBJS[@]} \
     -o kernel.bin


### PR DESCRIPTION
## Summary
- compile `fs.c` in the kernel and link it
- fix missing backslash when compiling `debuglog.c`
- document the build fixes in the release notes

## Testing
- `bash tests/test_ata_compile.sh`
- `bash tests/test_fatfs_compile.sh`
- `bash tests/test_mem.sh`
- `bash tests/test_fs.sh`


------
https://chatgpt.com/codex/tasks/task_e_685d3be4dc988330be5527f441d889dc