### PR TITLE
Kernel build fixes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,6 +10,7 @@
 - Headers now use `extern "C"` guards, preventing unresolved symbols when linking with C++
 - Fixed undefined references in `00_kernel_tester` by linking serial stubs and adding `strncmp`
 - Corrected ELF loader to handle 64-bit program headers, fixing invalid opcode crashes on boot
+- Kernel now links the I/O helper library so cpuid and rdtsc functions resolve
 
 ## Improvements
 - Added priority-based ballooning allocator

--- a/build.sh
+++ b/build.sh
@@ -160,7 +160,7 @@ EOF
 # 2) Clean generated artifacts
 rm -f arch/x86/boot.o arch/x86/idt.o \
       kernel/main.o kernel/mem.o kernel/console.o \
-      kernel/idt.o kernel/panic.o \
+      kernel/idt.o kernel/panic.o kernel/debuglog.o kernel/io.o \
       kernel.bin exocore.iso
 rm -rf isodir run/*.o run/*.elf run/*.bin run/linkdep_objs run/linkdep.a
 
@@ -313,30 +313,32 @@ BOOT_ARCH="$ARCH_FLAG"
 if [ "$arch_choice" = "3" ]; then
   BOOT_ARCH="-m64"
 fi
-$CC $BOOT_ARCH -std=gnu99 -ffreestanding -O2 -fcf-protection=none -Wall -Iinclude \
+$CC $BOOT_ARCH -std=gnu99 -ffreestanding -O2 -fcf-protection=none -Wall -U__linux__ -Iinclude \
     -c arch/x86/boot.S   -o arch/x86/boot.o
-$CC $ARCH_FLAG -std=gnu99 -ffreestanding -O2 -fcf-protection=none -Wall -Iinclude \
+$CC $ARCH_FLAG -std=gnu99 -ffreestanding -O2 -fcf-protection=none -Wall -U__linux__ -Iinclude \
     -c arch/x86/idt.S    -o arch/x86/idt.o
-$CC $ARCH_FLAG -std=gnu99 -ffreestanding -O2 -fcf-protection=none -Wall -Iinclude \
+$CC $ARCH_FLAG -std=gnu99 -ffreestanding -O2 -fcf-protection=none -Wall -U__linux__ -Iinclude \
     -c kernel/main.c    -o kernel/main.o
-$CC $ARCH_FLAG -std=gnu99 -ffreestanding -O2 -fcf-protection=none -Wall -Iinclude \
+$CC $ARCH_FLAG -std=gnu99 -ffreestanding -O2 -fcf-protection=none -Wall -U__linux__ -Iinclude \
     -c kernel/mem.c     -o kernel/mem.o
-$CC $ARCH_FLAG -std=gnu99 -ffreestanding -O2 -fcf-protection=none -Wall -Iinclude \
+$CC $ARCH_FLAG -std=gnu99 -ffreestanding -O2 -fcf-protection=none -Wall -U__linux__ -Iinclude \
     -c kernel/console.c -o kernel/console.o
-$CC $ARCH_FLAG -std=gnu99 -ffreestanding -O2 -fcf-protection=none -Wall -Iinclude \
+$CC $ARCH_FLAG -std=gnu99 -ffreestanding -O2 -fcf-protection=none -Wall -U__linux__ -Iinclude \
     -c kernel/serial.c -o kernel/serial.o
-$CC $ARCH_FLAG -std=gnu99 -ffreestanding -O2 -fcf-protection=none -Wall -Iinclude \
+$CC $ARCH_FLAG -std=gnu99 -ffreestanding -O2 -fcf-protection=none -Wall -U__linux__ -Iinclude \
     -c kernel/idt.c     -o kernel/idt.o
-$CC $ARCH_FLAG -std=gnu99 -ffreestanding -O2 -fcf-protection=none -Wall -Iinclude \
+$CC $ARCH_FLAG -std=gnu99 -ffreestanding -O2 -fcf-protection=none -Wall -U__linux__ -Iinclude \
     -c kernel/panic.c   -o kernel/panic.o
-$CC $ARCH_FLAG -std=gnu99 -ffreestanding -O2 -fcf-protection=none -Wall -Iinclude \
+$CC $ARCH_FLAG -std=gnu99 -ffreestanding -O2 -fcf-protection=none -Wall -U__linux__ -Iinclude \
     -c kernel/memutils.c -o kernel/memutils.o
-$CC $ARCH_FLAG -std=gnu99 -ffreestanding -O2 -fcf-protection=none -Wall -Iinclude \
+$CC $ARCH_FLAG -std=gnu99 -ffreestanding -O2 -fcf-protection=none -Wall -U__linux__ -Iinclude \
     -c kernel/fs.c -o kernel/fs.o
-$CC $ARCH_FLAG -std=gnu99 -ffreestanding -O2 -fcf-protection=none -Wall -Iinclude \
+$CC $ARCH_FLAG -std=gnu99 -ffreestanding -O2 -fcf-protection=none -Wall -U__linux__ -Iinclude \
     -c kernel/script.c -o kernel/script.o
-$CC $ARCH_FLAG -std=gnu99 -ffreestanding -O2 -fcf-protection=none -Wall -Iinclude \
+$CC $ARCH_FLAG -std=gnu99 -ffreestanding -O2 -fcf-protection=none -Wall -U__linux__ -Iinclude \
     -c kernel/debuglog.c -o kernel/debuglog.o
+$CC $ARCH_FLAG -std=gnu99 -ffreestanding -O2 -fcf-protection=none -Wall -U__linux__ -Iinclude \
+    -c linkdep/io.c -o kernel/io.o
 
 # 9) Link into flat kernel.bin
 echo "Linking kernel.bin..."
@@ -344,7 +346,7 @@ $LD -m $LDARCH -T linker.ld \
     arch/x86/boot.o arch/x86/idt.o \
     kernel/main.o kernel/mem.o kernel/console.o kernel/serial.o \
     kernel/idt.o kernel/panic.o kernel/memutils.o kernel/fs.o kernel/script.o \
-    kernel/debuglog.o \
+    kernel/debuglog.o kernel/io.o \
     kernel/micropython.o ${MP_OBJS[@]} \
     -o kernel.bin
 

--- a/kernel/debuglog.c
+++ b/kernel/debuglog.c
@@ -32,6 +32,7 @@ void debuglog_char(char c) {
 const char *debuglog_buffer(void) { return log_buf; }
 size_t debuglog_length(void) { return log_pos; }
 
+#if defined(__linux__) || defined(__APPLE__) || defined(_WIN32)
 static void json_escape(FILE *f, const char *s, size_t len) {
     for (size_t i = 0; i < len; i++) {
         char c = s[i];
@@ -41,6 +42,7 @@ static void json_escape(FILE *f, const char *s, size_t len) {
         else fputc(c, f);
     }
 }
+#endif
 
 void debuglog_save_file(void) {
 #if defined(__linux__) || defined(__APPLE__) || defined(_WIN32)

--- a/kernel/panic.c
+++ b/kernel/panic.c
@@ -13,6 +13,7 @@ extern volatile int current_user_app;
 const void *idt_data(void);
 size_t idt_size(void);
 
+#if defined(__linux__) || defined(__APPLE__) || defined(_WIN32)
 static void hexdump_file(FILE *f, const void *data, size_t len) {
     const unsigned char *p = (const unsigned char *)data;
     const char hex[] = "0123456789ABCDEF";
@@ -21,6 +22,7 @@ static void hexdump_file(FILE *f, const void *data, size_t len) {
         fputc(hex[p[i] & 0xF], f);
     }
 }
+#endif
 
 void panic_with_context(const char *msg, uint64_t rip, int user) {
     serial_init();


### PR DESCRIPTION
## Summary
- include generated io helper object in kernel build
- compile kernel with __linux__ undefined
- wrap stdio helpers in host-only guards

## Testing
- `./build.sh <<EOF
3
EOF`

------
https://chatgpt.com/codex/tasks/task_e_685d3ff303bc8330b06fdf1c20e554af