### PR TITLE
Fix logging build conditions

### DIFF
--- a/kernel/debuglog.c
+++ b/kernel/debuglog.c
@@ -4,7 +4,7 @@
 #include "fs.h"
 #include "console.h"
 #include "io.h"
-#if defined(__linux__) || defined(__APPLE__) || defined(_WIN32)
+#if __STDC_HOSTED__
 #include <stdio.h>
 #endif
 
@@ -32,7 +32,7 @@ void debuglog_char(char c) {
 const char *debuglog_buffer(void) { return log_buf; }
 size_t debuglog_length(void) { return log_pos; }
 
-#if defined(__linux__) || defined(__APPLE__) || defined(_WIN32)
+#if __STDC_HOSTED__
 static void json_escape(FILE *f, const char *s, size_t len) {
     for (size_t i = 0; i < len; i++) {
         char c = s[i];
@@ -45,7 +45,7 @@ static void json_escape(FILE *f, const char *s, size_t len) {
 #endif
 
 void debuglog_save_file(void) {
-#if defined(__linux__) || defined(__APPLE__) || defined(_WIN32)
+#if __STDC_HOSTED__
     FILE *f = fopen("exocoredebug.txt", "w");
     if (f) {
         fprintf(f, "{\n  \"events\": [\n");

--- a/kernel/panic.c
+++ b/kernel/panic.c
@@ -1,5 +1,5 @@
 #include <stdint.h>
-#if defined(__linux__) || defined(__APPLE__) || defined(_WIN32)
+#if __STDC_HOSTED__
 #include <stdio.h>
 #endif
 #include "console.h"
@@ -13,7 +13,7 @@ extern volatile int current_user_app;
 const void *idt_data(void);
 size_t idt_size(void);
 
-#if defined(__linux__) || defined(__APPLE__) || defined(_WIN32)
+#if __STDC_HOSTED__
 static void hexdump_file(FILE *f, const void *data, size_t len) {
     const unsigned char *p = (const unsigned char *)data;
     const char hex[] = "0123456789ABCDEF";
@@ -36,7 +36,7 @@ void panic_with_context(const char *msg, uint64_t rip, int user) {
 
     debuglog_save_file();
 
-#if defined(__linux__) || defined(__APPLE__) || defined(_WIN32)
+#if __STDC_HOSTED__
     FILE *f = fopen("exocorecrash.txt", "w");
     if (f) {
         fprintf(f, "{\n");


### PR DESCRIPTION
## Summary
- remove OS-specific preprocessor checks
- use `__STDC_HOSTED__` to gate host-only logging helpers

## Testing
- `./build.sh <<EOF
1
EOF`

------
https://chatgpt.com/codex/tasks/task_e_685d424f218c83309dccbe1d4b62faec