### PR TITLE
Add debug gating and VGA Micropython output control

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -106,3 +106,5 @@
 - Crash log exocorecrash.txt records RIP, program source and dumps IDT and nearby memory
 - Debug log saved in JSON format for easier machine parsing
 - Structured JSON events include timestamped messages for each step
+- Debug logs now only print when debug mode is enabled
+- MicroPython console output routed to VGA unless 'nompvga' kernel flag

--- a/build.sh
+++ b/build.sh
@@ -147,12 +147,31 @@ fi
 cat > "$MP_DIR/examples/embedding/micropython_embed/port/mphalport.c" <<'EOF'
 #include "console.h"
 #include "py/mphal.h"
+#include "runstate.h"
+
+mp_uint_t mp_hal_stdout_tx_strn(const char *str, size_t len) {
+    if (!mp_vga_output) return 0;
+    for (size_t i = 0; i < len; i++) {
+        console_putc(str[i]);
+    }
+    return len;
+}
+
 void mp_hal_stdout_tx_strn_cooked(const char *str, size_t len) {
+    if (!mp_vga_output) return;
     for (size_t i = 0; i < len; i++) {
         char c = str[i];
         if (c == '\n') console_putc('\r');
         console_putc(c);
     }
+}
+
+mp_uint_t mp_hal_stderr_tx_strn(const char *str, size_t len) {
+    if (!mp_vga_output) return 0;
+    for (size_t i = 0; i < len; i++) {
+        console_putc(str[i]);
+    }
+    return len;
 }
 EOF
 

--- a/include/runstate.h
+++ b/include/runstate.h
@@ -7,6 +7,8 @@ extern "C" {
 
 extern volatile const char *current_program;
 extern volatile int current_user_app;
+extern int debug_mode;
+extern int mp_vga_output;
 
 #ifdef __cplusplus
 }

--- a/kernel/debuglog.c
+++ b/kernel/debuglog.c
@@ -4,6 +4,7 @@
 #include "fs.h"
 #include "console.h"
 #include "serial.h"
+#include "runstate.h"
 #include "io.h"
 #if __STDC_HOSTED__
 #include <stdio.h>
@@ -108,7 +109,7 @@ void debuglog_flush(void) {
 }
 
 void debuglog_dump_console(void) {
-    if (!log_buf) return;
+    if (!log_buf || !debug_mode) return;
     for (size_t i = 0; i < log_pos; i++) {
         console_putc(log_buf[i]);
         serial_raw_putc(log_buf[i]);
@@ -118,6 +119,7 @@ void debuglog_dump_console(void) {
 static const char hex_digits[] = "0123456789ABCDEF";
 
 void debuglog_hexdump(const void *data, size_t len) {
+    if (!debug_mode) return;
     const unsigned char *p = (const unsigned char *)data;
     for (size_t i = 0; i < len; i++) {
         char hi = hex_digits[p[i] >> 4];
@@ -133,6 +135,7 @@ void debuglog_hexdump(const void *data, size_t len) {
 }
 
 void debuglog_memdump(const void *addr, size_t len) {
+    if (!debug_mode) return;
     const unsigned char *p = (const unsigned char *)addr;
     for (size_t i = 0; i < len; i += 16) {
         uint64_t pos = (uint64_t)((uintptr_t)addr + i);
@@ -145,6 +148,7 @@ void debuglog_memdump(const void *addr, size_t len) {
 }
 
 void debuglog_print_timestamp(void) {
+    if (!debug_mode) return;
     uint64_t delta = io_rdtsc() - log_start;
     console_puts("["); serial_raw_write("[");
     console_puts("ts=0x"); serial_raw_write("ts=0x");

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -16,8 +16,9 @@
 #include "script.h"
 #include "micropython.h"
 
-static int debug_mode = 0;
+int debug_mode = 0;
 static int userland_mode = 0;
+int mp_vga_output = 1;
 volatile const char *current_program = "kernel";
 volatile int current_user_app = 0;
 
@@ -28,6 +29,8 @@ static void parse_cmdline(const char *cmd) {
             debug_mode = 1;
         if (!userland_mode && !strncmp(p, "userland", 8))
             userland_mode = 1;
+        if (mp_vga_output && !strncmp(p, "nompvga", 7))
+            mp_vga_output = 0;
     }
 }
 


### PR DESCRIPTION
## Summary
- only print debug logs when `debug` mode is set
- route MicroPython output to VGA by default and allow disabling via `nompvga` kernel arg
- expose `debug_mode` and `mp_vga_output` globals
- update release notes

## Testing
- `./tests/full_kernel_test.sh` *(fails: missing CPU log)*

------
https://chatgpt.com/codex/tasks/task_e_68628ae1c6c08330b7df05aed0a326dc