### PR TITLE
Add shebang-based MicroPython loader

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -71,6 +71,7 @@
 - MicroPython runtime integrated; '.py' modules now execute via embedded interpreter
 - Compiled '.mpy' files are packaged in the ISO and loaded instead of '.py'
 - Added `run/micropython_test.py` example to verify MicroPython script loading
+- Files starting with `#mpyexo` execute as MicroPython scripts when not valid ELF binaries
 
 ## Bug Fixes
 - Fixed MicroPython build errors by adding missing include path and implementing libc stubs.


### PR DESCRIPTION
## Summary
- support running text modules starting with `#mpyexo` through MicroPython
- document new feature in the release notes

## Testing
- `bash tests/test_mem.sh` *(fails: undefined references)*
- `bash tests/test_fatfs_compile.sh`
- `bash tests/test_ata_compile.sh`
- `bash tests/test_fs.sh` *(fails: undefined references)*

------
https://chatgpt.com/codex/tasks/task_e_68628ef180548330ab60bd5d77bc339d