### PR TITLE
Fix MicroPython console output on serial

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -110,3 +110,4 @@
 - Debug logs now only print when debug mode is enabled
 - MicroPython console output routed to VGA unless 'nompvga' kernel flag
 - Raw '.py' modules are now copied directly to the ISO instead of being compiled to '.mpy'
+- Fixed MicroPython output not appearing on serial by routing stdout/stderr to serial

--- a/build.sh
+++ b/build.sh
@@ -146,11 +146,13 @@ fi
 # patch stdout handler to use kernel console
 cat > "$MP_DIR/examples/embedding/micropython_embed/port/mphalport.c" <<'EOF'
 #include "console.h"
+#include "serial.h"
 #include "py/mphal.h"
 #include "runstate.h"
 
 mp_uint_t mp_hal_stdout_tx_strn(const char *str, size_t len) {
-    if (!mp_vga_output) return 0;
+    serial_write(str);
+    if (!mp_vga_output) return len;
     for (size_t i = 0; i < len; i++) {
         console_putc(str[i]);
     }
@@ -158,6 +160,7 @@ mp_uint_t mp_hal_stdout_tx_strn(const char *str, size_t len) {
 }
 
 void mp_hal_stdout_tx_strn_cooked(const char *str, size_t len) {
+    serial_write(str);
     if (!mp_vga_output) return;
     for (size_t i = 0; i < len; i++) {
         char c = str[i];
@@ -167,7 +170,8 @@ void mp_hal_stdout_tx_strn_cooked(const char *str, size_t len) {
 }
 
 mp_uint_t mp_hal_stderr_tx_strn(const char *str, size_t len) {
-    if (!mp_vga_output) return 0;
+    serial_write(str);
+    if (!mp_vga_output) return len;
     for (size_t i = 0; i < len; i++) {
         console_putc(str[i]);
     }


### PR DESCRIPTION
## Summary
- route MicroPython's stdout/stderr to serial so scripts print in nographic mode
- document fix in release notes

## Testing
- `./build.sh`

------
https://chatgpt.com/codex/tasks/task_e_686297e9bbcc8330b63763b00f9091c3