### PR TITLE
Fix end symbol declaration in kernel_main

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,6 +11,7 @@
 - Fixed undefined references in `00_kernel_tester` by linking serial stubs and adding `strncmp`
 - Corrected ELF loader to handle 64-bit program headers, fixing invalid opcode crashes on boot
 - Kernel now links the I/O helper library so cpuid and rdtsc functions resolve
+- Fixed missing global declaration for `end` symbol causing build failures in `kernel_main`
 
 ## Improvements
 - Added priority-based ballooning allocator

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -22,6 +22,9 @@ int mp_vga_output = 1;
 volatile const char *current_program = "kernel";
 volatile int current_user_app = 0;
 
+/* Symbol defined by the linker marking the end of the kernel image */
+extern uint8_t end;
+
 static inline void dbg_puts(const char *s) { if (debug_mode) console_puts(s); }
 static inline void dbg_putc(char c) { if (debug_mode) console_putc(c); }
 static inline void dbg_udec(uint32_t v) { if (debug_mode) console_udec(v); }
@@ -82,7 +85,6 @@ void kernel_main(uint32_t magic, multiboot_info_t *mbi) {
         dbg_puts(" ecx=0x");
         dbg_uhex(ecx);
         dbg_putc('\n');
-        extern uint8_t end;
         dbg_puts("Initializing memory manager at 0x");
         dbg_uhex((uint64_t)(uintptr_t)&end);
         dbg_puts("\n");


### PR DESCRIPTION
## Summary
- declare linker-provided `end` symbol at global scope
- remove duplicate local declaration
- document build fix in release notes

## Testing
- `./tests/test_mem.sh` *(fails: undefined references to debug_mode and serial functions)*

------
https://chatgpt.com/codex/tasks/task_e_686397e2e5b8833097fa59a7f67aeb09