### PR TITLE
Fix module build bootlogo dependency

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -115,3 +115,4 @@
 - Carriage returns in MicroPython output no longer show as garbage on the VGA console
 - Verbose boot logs only appear when debug mode is enabled
 - Optional boot logo rendered during boot; sample BMP removed for user customization
+- Module build now compiles a bootlogo stub so missing NO_BOOTLOGO flags no longer cause linking errors

--- a/build.sh
+++ b/build.sh
@@ -203,6 +203,7 @@ EOF
 fi
 
 # 4) Compile linkdep/*.c → run/linkdep_objs/*.o
+# compile link dependency sources
 for src in linkdep/*.c; do
   [ -f "$src" ] || continue
   obj="run/linkdep_objs/$(basename "${src%.c}.o")"
@@ -210,6 +211,12 @@ for src in linkdep/*.c; do
   $CC $MODULE_FLAG -std=gnu99 -ffreestanding -O2 -fcf-protection=none -nostdlib -nodefaultlibs \
       -Iinclude -c "$src" -o "$obj"
 done
+# additionally build a stub for bootlogo functions so modules don't require the
+# full bootlogo implementation
+bootlogo_obj="run/linkdep_objs/bootlogo.o"
+echo "Compiling linkdep kernel/bootlogo.c → $bootlogo_obj"
+$CC $MODULE_FLAG -std=gnu99 -ffreestanding -O2 -fcf-protection=none -nostdlib -nodefaultlibs \
+    -DNO_BOOTLOGO -Iinclude -c kernel/bootlogo.c -o "$bootlogo_obj"
 
 # archive deps so ld only pulls used ones
 shopt -s nullglob


### PR DESCRIPTION
## Summary
- compile a bootlogo stub in the linkdep library
- document fix in release notes

## Testing
- `./build.sh <<EOF
1
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6864ed7a57808330978a8327d69c8cba