### PR TITLE
Document kernel module loader usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 * Simple memory-backed filesystem driver that can mount, read, and write storage
 * FAT filesystem driver for real disks with bad sector detection
 * Basic ATA PIO driver for block storage access
+* Kernel-integrated MicroPython loader scanning `/mpymod` ([docs](docs/Kernel-Integrated-Module-Loader.md))
 
 ## Prerequisites
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -114,3 +114,5 @@
 - Fixed MicroPython output not appearing on serial by routing stdout/stderr to serial
 - Carriage returns in MicroPython output no longer show as garbage on the VGA console
 - Verbose boot logs only appear when debug mode is enabled
+- Documented kernel-integrated MicroPython module loader design
+- Added usage instructions and native module example

--- a/docs/Kernel-Integrated-Module-Loader.md
+++ b/docs/Kernel-Integrated-Module-Loader.md
@@ -1,0 +1,75 @@
+# ExoCore Kernel-Integrated Module Loader
+
+This document outlines the design for a kernel level loader capable of scanning directories under `/mpymod` at boot. Each directory provides a `manifest.json` describing a MicroPython bytecode module and any associated native modules that should be registered.
+
+## Directory layout
+```
+/mpymod/<name>/manifest.json
+/mpymod/<name>/<module>.mpy
+/mpymod/<name>/native/
+```
+
+The manifest contains:
+- `mpy_entry` – path to the `.mpy` file to execute
+- `mpy_import_as` – name used when inserting the module into `sys.modules`
+- `c_modules` – list of native modules, specified as objects containing `name` and `path`
+
+Example:
+```json
+{
+  "mpy_entry": "mod.mpy",
+  "mpy_import_as": "testmod",
+  "c_modules": [
+    {"name": "board", "path": "native/board.o"}
+  ]
+}
+```
+
+## Boot behaviour
+1. The kernel enumerates `/mpymod/*` folders.
+2. For each folder the manifest is parsed.
+3. The `.mpy` file is loaded through the MicroPython C API using `mp_embed_exec_mpy`.
+4. The resulting module object is stored in `sys.modules` under the name provided by `mpy_import_as`.
+5. Entries in `c_modules` are matched against built‑in native modules and registered if present.
+
+All modules are loaded before any user applications run so Python code can invoke them immediately without a separate loader.
+
+## Using the loader
+
+1. Compile your Python code into bytecode using `mpy-cross`:
+   ```bash
+   mpy-cross mylib.py
+   ```
+   This produces `mylib.mpy`.
+2. Create `/mpymod/mylib/manifest.json` with the following fields:
+   ```json
+   {
+     "mpy_entry": "mylib.mpy",
+     "mpy_import_as": "mylib",
+     "c_modules": []
+   }
+   ```
+3. Place `mylib.mpy` alongside the manifest in the same folder on the boot image.
+4. Rebuild the ISO and boot the kernel. At the console you can now run:
+   ```python
+   import mylib
+   ```
+   and the module loads automatically.
+
+## Creating native libraries
+
+Native modules may be written in C for performance or hardware access.
+Compile the object file with your cross compiler and list it in the manifest:
+
+```json
+{
+  "mpy_entry": "mylib.mpy",
+  "mpy_import_as": "mylib",
+  "c_modules": [
+    {"name": "board", "path": "native/board.o"}
+  ]
+}
+```
+
+The kernel matches the `name` field with built‑in module stubs. When present the
+object is loaded so `import mylib` exposes the native functionality.

--- a/tests/stub_console.c
+++ b/tests/stub_console.c
@@ -1,4 +1,7 @@
 #include "../include/console.h"
+#include "../include/serial.h"
+
+int debug_mode = 0;
 void console_init(void) {}
 void console_putc(char c) { (void)c; }
 void console_puts(const char *s) { (void)s; }
@@ -10,3 +13,12 @@ char console_getc(void) { return 0; }
 void console_set_attr(uint8_t fg, uint8_t bg) { (void)fg; (void)bg; }
 void console_scroll_up(void) {}
 void console_scroll_down(void) {}
+
+void serial_init(void) {}
+void serial_putc(char c) { (void)c; }
+void serial_write(const char *s) { (void)s; }
+void serial_udec(uint32_t v) { (void)v; }
+void serial_uhex(uint64_t val) { (void)val; }
+void serial_raw_putc(char c) { (void)c; }
+void serial_raw_write(const char *s) { (void)s; }
+void serial_raw_uhex(uint64_t val) { (void)val; }


### PR DESCRIPTION
## Summary
- add a link to MicroPython loader docs in the README
- flesh out docs on using the MicroPython module loader and writing native extensions
- include updated release notes
- expand test stubs so `debug_mode` and serial helpers are defined

## Testing
- `tests/test_mem.sh`
- `tests/test_fs.sh`


------
https://chatgpt.com/codex/tasks/task_e_6865cdde22c88330b1f9b2f8de233dbe