### PR TITLE
Add VGA toggle MicroPython module

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -93,6 +93,30 @@ mp_uint_t mp_hal_stderr_tx_strn(const char *str, size_t len) {
 }
 EOF
 
+# Provide a MicroPython module to toggle VGA output
+cat > "$MP_DIR/examples/embedding/micropython_embed/port/modvga.c" <<'EOF'
+#include "py/obj.h"
+#include "runstate.h"
+
+STATIC mp_obj_t vga_enable(mp_obj_t enable) {
+    mp_vga_output = mp_obj_is_true(enable);
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(vga_enable_obj, vga_enable);
+
+STATIC const mp_rom_map_elem_t vga_globals_table[] = {
+    { MP_ROM_QSTR(MP_QSTR_enable), MP_ROM_PTR(&vga_enable_obj) },
+};
+STATIC MP_DEFINE_CONST_DICT(vga_module_globals, vga_globals_table);
+
+const mp_obj_module_t mp_module_vga = {
+    .base = { &mp_type_module },
+    .globals = (mp_obj_dict_t *)&vga_module_globals,
+};
+
+MP_REGISTER_MODULE(MP_QSTR_vga, mp_module_vga);
+EOF
+
 # 1) Target selection & tool fallback installer
 echo "Select target architecture, comma-separated choices:"
 echo " 1) native (host)"

--- a/mpymod/vga_demo/demo.py
+++ b/mpymod/vga_demo/demo.py
@@ -1,0 +1,4 @@
+print("vgademo module loaded")
+import vga
+vga.enable(True)
+print("vgademo enabled VGA output")

--- a/mpymod/vga_demo/manifest.json
+++ b/mpymod/vga_demo/manifest.json
@@ -1,0 +1,5 @@
+{
+  "mpy_entry": "demo.py",
+  "mpy_import_as": "vgademo",
+  "c_modules": []
+}

--- a/run/vga_demo.py
+++ b/run/vga_demo.py
@@ -1,0 +1,7 @@
+#mpyexo
+import vga
+print("VGA demo started")
+vga.enable(True)
+print("This should appear on both VGA and serial")
+vga.enable(False)
+print("VGA disabled")


### PR DESCRIPTION
## Summary
- implement a new `vga` MicroPython module for controlling VGA output
- add demonstration script `run/vga_demo.py`
- include example `mpymod` entry showing how to package a module

## Testing
- `bash tests/test_mem.sh`
- `bash tests/test_fs.sh`
- `bash tests/test_ata_compile.sh`
- `bash tests/test_fatfs_compile.sh`


------
https://chatgpt.com/codex/tasks/task_e_6867af370970833090bd61900d6bb75a