### PR TITLE
Add VGA serial toggle

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -116,3 +116,6 @@
 - Verbose boot logs only appear when debug mode is enabled
 - Documented kernel-integrated MicroPython module loader design
 - Added usage instructions and native module example
+- Added built-in 'vga' MicroPython module and example script
+- VGA module now allows toggling serial output with `vga.serial()`
+- Build script auto-includes all C modules under `extras/`

--- a/build.sh
+++ b/build.sh
@@ -62,36 +62,47 @@ cat > "$MP_DIR/examples/embedding/micropython_embed/port/mphalport.c" <<'EOF'
 #include "console.h"
 #include "serial.h"
 #include "py/mphal.h"
-#include "runstate.h"
+extern int mp_vga_output;
+extern int mp_serial_output;
 
 mp_uint_t mp_hal_stdout_tx_strn(const char *str, size_t len) {
-    serial_write(str);
-    if (!mp_vga_output) return len;
-    for (size_t i = 0; i < len; i++) {
-        console_putc(str[i]);
+    if (mp_serial_output) serial_write(str);
+    if (mp_vga_output) {
+        for (size_t i = 0; i < len; i++) {
+            console_putc(str[i]);
+        }
     }
     return len;
 }
 
 void mp_hal_stdout_tx_strn_cooked(const char *str, size_t len) {
-    serial_write(str);
-    if (!mp_vga_output) return;
-    for (size_t i = 0; i < len; i++) {
-        char c = str[i];
-        if (c == '\n') console_putc('\r');
-        console_putc(c);
+    if (mp_serial_output) serial_write(str);
+    if (mp_vga_output) {
+        for (size_t i = 0; i < len; i++) {
+            char c = str[i];
+            if (c == '\n') console_putc('\r');
+            console_putc(c);
+        }
     }
 }
 
 mp_uint_t mp_hal_stderr_tx_strn(const char *str, size_t len) {
-    serial_write(str);
-    if (!mp_vga_output) return len;
-    for (size_t i = 0; i < len; i++) {
-        console_putc(str[i]);
+    if (mp_serial_output) serial_write(str);
+    if (mp_vga_output) {
+        for (size_t i = 0; i < len; i++) {
+            console_putc(str[i]);
+        }
     }
     return len;
 }
 EOF
+
+# Copy all extras/*.c modules for MicroPython
+mkdir -p "$MP_DIR/ports/embed/port"
+for m in extras/*.c; do
+  [ -f "$m" ] || continue
+  cp "$m" "$MP_DIR/ports/embed/port/$(basename "$m")"
+done
 
 # 1) Target selection & tool fallback installer
 echo "Select target architecture, comma-separated choices:"

--- a/extras/modvga.c
+++ b/extras/modvga.c
@@ -1,0 +1,28 @@
+#include "py/runtime.h"
+extern int mp_vga_output;
+extern int mp_serial_output;
+
+static mp_obj_t vga_enable(mp_obj_t enable) {
+    mp_vga_output = mp_obj_is_true(enable);
+    return mp_const_none;
+}
+static MP_DEFINE_CONST_FUN_OBJ_1(vga_enable_obj, vga_enable);
+
+static mp_obj_t vga_serial(mp_obj_t enable) {
+    mp_serial_output = mp_obj_is_true(enable);
+    return mp_const_none;
+}
+static MP_DEFINE_CONST_FUN_OBJ_1(vga_serial_obj, vga_serial);
+
+static const mp_rom_map_elem_t vga_globals_table[] = {
+    { MP_ROM_QSTR(MP_QSTR_enable), MP_ROM_PTR(&vga_enable_obj) },
+    { MP_ROM_QSTR(MP_QSTR_serial), MP_ROM_PTR(&vga_serial_obj) },
+};
+static MP_DEFINE_CONST_DICT(vga_module_globals, vga_globals_table);
+
+const mp_obj_module_t mp_module_vga = {
+    .base = { &mp_type_module },
+    .globals = (mp_obj_dict_t *)&vga_module_globals,
+};
+
+MP_REGISTER_MODULE(MP_QSTR_vga, mp_module_vga);

--- a/include/runstate.h
+++ b/include/runstate.h
@@ -9,6 +9,7 @@ extern volatile const char *current_program;
 extern volatile int current_user_app;
 extern int debug_mode;
 extern int mp_vga_output;
+extern int mp_serial_output;
 
 #ifdef __cplusplus
 }

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -19,6 +19,7 @@
 int debug_mode = 0;
 static int userland_mode = 0;
 int mp_vga_output = 1;
+int mp_serial_output = 1;
 volatile const char *current_program = "kernel";
 volatile int current_user_app = 0;
 
@@ -39,6 +40,8 @@ static void parse_cmdline(const char *cmd) {
             userland_mode = 1;
         if (mp_vga_output && !strncmp(p, "nompvga", 7))
             mp_vga_output = 0;
+        if (mp_serial_output && !strncmp(p, "noserial", 8))
+            mp_serial_output = 0;
     }
 }
 

--- a/mpymod/vga_demo/demo.py
+++ b/mpymod/vga_demo/demo.py
@@ -1,0 +1,9 @@
+print("vgademo module loaded")
+import vga
+vga.enable(True)
+print("mpymod demo both")
+vga.serial(False)
+print("mpymod demo vga only")
+vga.serial(True)
+vga.enable(False)
+print("mpymod demo serial only")

--- a/mpymod/vga_demo/manifest.json
+++ b/mpymod/vga_demo/manifest.json
@@ -1,0 +1,5 @@
+{
+  "mpy_entry": "demo.py",
+  "mpy_import_as": "vgademo",
+  "c_modules": []
+}

--- a/run/vga_demo.py
+++ b/run/vga_demo.py
@@ -1,0 +1,10 @@
+#mpyexo
+import vga
+print("VGA demo started")
+vga.enable(True)
+print("Both outputs")
+vga.serial(False)
+print("VGA only")
+vga.serial(True)
+vga.enable(False)
+print("Serial only")


### PR DESCRIPTION
## Summary
- patch MicroPython output layer to allow serial or VGA routing
- include all extras C modules automatically when building
- extend `vga` module with `serial()` control and update demos
- new global `mp_serial_output` for runtime configuration

## Testing
- `bash tests/test_mem.sh`
- `bash tests/test_fs.sh`
- `bash tests/test_ata_compile.sh`
- `bash tests/test_fatfs_compile.sh`


------
https://chatgpt.com/codex/tasks/task_e_6867af370970833090bd61900d6bb75a