### PR TITLE
Update module build process

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 * Minimal exokernel core written in C and assembly
 * Console I/O stub (`run/console_mod.o`) for linking native code
-* Build script packages `.py` or `.mpy` files in `run/` as MicroPython modules
+* Build script packages `.py` files in `run/` as MicroPython modules
 * ISO packaging via GRUB for easy QEMU testing
 * Interrupt descriptor table with fault-driven panics
 * TinyScript interpreter allows text-based `.ts` modules
@@ -72,7 +72,7 @@ qemu-system-x86_64 -cdrom exocore.iso -m 128M
 
 ## Adding Your Own Code
 
-1. Place your Python file (e.g. `myapp.py` or precompiled `myapp.mpy`) into the `run/` directory.
+1. Place your Python file (e.g. `myapp.py`) into the `run/` directory.
 2. Rebuild with `./build.sh`; the script packages these MicroPython modules automatically.
 3. Select your new module in QEMU via the boot menu or launch it directly.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -116,3 +116,5 @@
 - Verbose boot logs only appear when debug mode is enabled
 - Documented kernel-integrated MicroPython module loader design
 - Added usage instructions and native module example
+- Build script now detects modules in `mpymod` and links listed native sources
+- Removed obsolete example VGA MicroPython module causing build errors

--- a/docs/Kernel-Integrated-Module-Loader.md
+++ b/docs/Kernel-Integrated-Module-Loader.md
@@ -1,23 +1,23 @@
 # ExoCore Kernel-Integrated Module Loader
 
-This document outlines the design for a kernel level loader capable of scanning directories under `/mpymod` at boot. Each directory provides a `manifest.json` describing a MicroPython bytecode module and any associated native modules that should be registered.
+This document outlines the design for a kernel level loader capable of scanning directories under `/mpymod` at boot. Each directory provides a `manifest.json` describing a MicroPython module and any associated native modules that should be registered.
 
 ## Directory layout
 ```
 /mpymod/<name>/manifest.json
-/mpymod/<name>/<module>.mpy
+/mpymod/<name>/<module>.py
 /mpymod/<name>/native/
 ```
 
 The manifest contains:
-- `mpy_entry` – path to the `.mpy` file to execute
+- `mpy_entry` – path to the `.py` file to execute
 - `mpy_import_as` – name used when inserting the module into `sys.modules`
 - `c_modules` – list of native modules, specified as objects containing `name` and `path`
 
 Example:
 ```json
 {
-  "mpy_entry": "mod.mpy",
+  "mpy_entry": "mod.py",
   "mpy_import_as": "testmod",
   "c_modules": [
     {"name": "board", "path": "native/board.o"}
@@ -28,7 +28,7 @@ Example:
 ## Boot behaviour
 1. The kernel enumerates `/mpymod/*` folders.
 2. For each folder the manifest is parsed.
-3. The `.mpy` file is loaded through the MicroPython C API using `mp_embed_exec_mpy`.
+3. The `.py` file is executed through the MicroPython C API.
 4. The resulting module object is stored in `sys.modules` under the name provided by `mpy_import_as`.
 5. Entries in `c_modules` are matched against built‑in native modules and registered if present.
 
@@ -36,20 +36,16 @@ All modules are loaded before any user applications run so Python code can invok
 
 ## Using the loader
 
-1. Compile your Python code into bytecode using `mpy-cross`:
-   ```bash
-   mpy-cross mylib.py
-   ```
-   This produces `mylib.mpy`.
+1. Write your Python library `mylib.py`.
 2. Create `/mpymod/mylib/manifest.json` with the following fields:
    ```json
    {
-     "mpy_entry": "mylib.mpy",
+     "mpy_entry": "mylib.py",
      "mpy_import_as": "mylib",
      "c_modules": []
    }
    ```
-3. Place `mylib.mpy` alongside the manifest in the same folder on the boot image.
+3. Place `mylib.py` alongside the manifest in the same folder on the boot image.
 4. Rebuild the ISO and boot the kernel. At the console you can now run:
    ```python
    import mylib
@@ -63,7 +59,7 @@ Compile the object file with your cross compiler and list it in the manifest:
 
 ```json
 {
-  "mpy_entry": "mylib.mpy",
+"mpy_entry": "mylib.py",
   "mpy_import_as": "mylib",
   "c_modules": [
     {"name": "board", "path": "native/board.o"}


### PR DESCRIPTION
## Summary
- remove deprecated VGA module code
- automatically gather MicroPython modules from `mpymod`
- update kernel module loader docs for `.py` usage
- tweak README and release notes

## Testing
- `bash tests/test_ata_compile.sh`
- `bash tests/test_fatfs_compile.sh`
- `bash tests/test_fs.sh`
- `bash tests/test_mem.sh`


------
https://chatgpt.com/codex/tasks/task_e_6867b5ac6dd88330ab2b9a22d562c50a