### PR TITLE
Fix VGA import

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -93,6 +93,13 @@ mp_uint_t mp_hal_stderr_tx_strn(const char *str, size_t len) {
 }
 EOF
 
+# ensure qstr for built-in VGA module
+if ! grep -q "^Q(vga)$" "$MP_DIR/examples/embedding/micropython_embed/py/qstrdefs.h"; then
+  echo "Q(vga)" >> "$MP_DIR/examples/embedding/micropython_embed/py/qstrdefs.h"
+  rm -rf "$MP_DIR/examples/embedding/build-embed"
+  make -C "$MP_DIR/examples/embedding" -f micropython_embed.mk
+fi
+
 # Previously an example VGA control module was injected here. It
 # caused build failures with newer MicroPython headers and isn't used
 # by the kernel, so it has been removed.
@@ -352,7 +359,9 @@ if [ -d mpymod ]; then
       src="$moddir/$cpath"
       obj="$MP_BUILD/${name}_$(basename "${cpath%.*}.o")"
       echo "Compiling mpymod native $src → $obj"
-      $CC $ARCH_FLAG -std=gnu99 -ffreestanding -O2 -Iinclude -c "$src" -o "$obj"
+      $CC $ARCH_FLAG -std=gnu99 -ffreestanding -O2 -Iinclude \
+          -I"$MP_DIR/examples/embedding" -I"$MP_SRC" -I"$MP_SRC/port" \
+          -c "$src" -o "$obj"
       MP_OBJS+=("$obj")
     done < <(python3 - <<'EOF' "$manifest"
 import json,sys

--- a/mpymod/vga/manifest.json
+++ b/mpymod/vga/manifest.json
@@ -1,0 +1,7 @@
+{
+  "mpy_entry": "",
+  "mpy_import_as": "vga",
+  "c_modules": [
+    {"name": "vga", "path": "native/vga.c"}
+  ]
+}

--- a/mpymod/vga/native/vga.c
+++ b/mpymod/vga/native/vga.c
@@ -1,0 +1,24 @@
+#include "py/runtime.h"
+#include "runstate.h"
+
+#ifndef STATIC
+#define STATIC static
+#endif
+
+STATIC mp_obj_t vga_enable(mp_obj_t flag) {
+    mp_vga_output = mp_obj_is_true(flag);
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(vga_enable_obj, vga_enable);
+
+STATIC const mp_rom_map_elem_t vga_module_globals_table[] = {
+    { MP_ROM_QSTR(MP_QSTR_enable), MP_ROM_PTR(&vga_enable_obj) },
+};
+STATIC MP_DEFINE_CONST_DICT(vga_module_globals, vga_module_globals_table);
+
+const mp_obj_module_t mp_module_vga = {
+    .base = { &mp_type_module },
+    .globals = (mp_obj_dict_t*)&vga_module_globals,
+};
+
+MP_REGISTER_MODULE(MP_QSTR_vga, mp_module_vga);

--- a/run/vga.py
+++ b/run/vga.py
@@ -1,0 +1,2 @@
+def enable(flag):
+    pass


### PR DESCRIPTION
## Summary
- add a simple `vga` stub module for MicroPython
- compile a native VGA control module and include manifest
- ensure MicroPython build picks up the VGA module

## Testing
- `./build.sh >/tmp/build.log <<'EOF'
1
EOF`
- `./build.sh run nographic <<'EOF'
1
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6867b9983950833093d86aa2b06f32c6