### PR TITLE
Kernel auto-loads mpymod modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Install the following on Ubuntu (or a similar Linux distribution):
    ./build.sh
    ```
 
-   When executed, `build.sh` automatically checks for updates from the GitHub repository and offers to apply them before building.
+   When executed, `build.sh` automatically checks for updates from this repository and the bundled Micropython source, applying them before building.
 
    This will clean previous builds, compile the kernel stub, package MicroPython modules from `run/`, link with GRUB, and produce `exocore.iso`.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -118,3 +118,5 @@
 - Added usage instructions and native module example
 - Build script now detects modules in `mpymod` and links listed native sources
 - Removed obsolete example VGA MicroPython module causing build errors
+- Kernel automatically loads modules from /mpymod at boot using a persistent MicroPython runtime
+- Build script keeps the Micropython source up to date automatically

--- a/include/micropython.h
+++ b/include/micropython.h
@@ -2,9 +2,16 @@
 #define MICROPYTHON_H
 #include <stddef.h>
 #include <stdint.h>
-// Ensure these functions are entered with a 16-byte aligned stack
+
+void mp_runtime_init(void);
+void mp_runtime_deinit(void);
+void mp_runtime_exec(const char *code, size_t size);
+void mp_runtime_exec_mpy(const uint8_t *buf, size_t size);
+
+// legacy single-shot helpers
 void run_micropython(const char *code, size_t size)
     __attribute__((force_align_arg_pointer));
 void run_micropython_mpy(const uint8_t *buf, size_t size)
     __attribute__((force_align_arg_pointer));
+
 #endif

--- a/include/mpy_loader.h
+++ b/include/mpy_loader.h
@@ -1,0 +1,25 @@
+#ifndef MPY_LOADER_H
+#define MPY_LOADER_H
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+    const char *name;        // module import name
+    const char *source;      // python source code
+    size_t source_len;       // length of source
+} mpymod_entry_t;
+
+extern const mpymod_entry_t mpymod_table[];
+extern const size_t mpymod_table_count;
+
+void mpymod_load_all(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MPY_LOADER_H */

--- a/kernel/micropython.c
+++ b/kernel/micropython.c
@@ -5,26 +5,48 @@
 #include <string.h>
 
 static char mp_heap[64 * 1024];
+static int mp_active = 0;
+static int mp_stack_top;
 
-__attribute__((force_align_arg_pointer))
-void run_micropython(const char *code, size_t size) {
-    int stack_top;
-    mp_embed_init(mp_heap, sizeof(mp_heap), &stack_top);
-    char *buf = mem_alloc(size + 1);
-    if (!buf) {
-        mp_embed_deinit();
-        return;
+void mp_runtime_init(void) {
+    if (!mp_active) {
+        mp_embed_init(mp_heap, sizeof(mp_heap), &mp_stack_top);
+        mp_active = 1;
     }
+}
+
+void mp_runtime_deinit(void) {
+    if (mp_active) {
+        mp_embed_deinit();
+        mp_active = 0;
+    }
+}
+
+void mp_runtime_exec(const char *code, size_t size) {
+    mp_runtime_init();
+    char *buf = mem_alloc(size + 1);
+    if (!buf)
+        return;
     memcpy(buf, code, size);
     buf[size] = '\0';
     mp_embed_exec_str(buf);
-    mp_embed_deinit();
+}
+
+void mp_runtime_exec_mpy(const uint8_t *buf, size_t size) {
+    mp_runtime_init();
+    mp_embed_exec_mpy(buf, size);
+}
+
+__attribute__((force_align_arg_pointer))
+void run_micropython(const char *code, size_t size) {
+    mp_runtime_init();
+    mp_runtime_exec(code, size);
+    mp_runtime_deinit();
 }
 
 __attribute__((force_align_arg_pointer))
 void run_micropython_mpy(const uint8_t *buf, size_t size) {
-    int stack_top;
-    mp_embed_init(mp_heap, sizeof(mp_heap), &stack_top);
-    mp_embed_exec_mpy(buf, size);
-    mp_embed_deinit();
+    mp_runtime_init();
+    mp_runtime_exec_mpy(buf, size);
+    mp_runtime_deinit();
 }

--- a/kernel/mpy_loader.c
+++ b/kernel/mpy_loader.c
@@ -1,0 +1,32 @@
+#include "mpy_loader.h"
+#include "micropython.h"
+#include "mem.h"
+#include <string.h>
+
+void mpymod_load_all(void) {
+    for (size_t i = 0; i < mpymod_table_count; ++i) {
+        const mpymod_entry_t *m = &mpymod_table[i];
+        const char prefix1[] = "import sys, types\nmod = types.ModuleType('";
+        const char prefix2[] = "')\nexec(\"\"\"\n";
+        const char prefix3[] = "\"\", mod.__dict__)\nsys.modules['";
+        const char prefix4[] = "'] = mod\n";
+        size_t name_len = strlen(m->name);
+        size_t total = sizeof(prefix1) - 1 + name_len +
+                       sizeof(prefix2) - 1 + m->source_len + 1 +
+                       sizeof(prefix3) - 1 + name_len + sizeof(prefix4) - 1;
+        char *buf = mem_alloc(total + 1);
+        if (!buf)
+            continue;
+        char *p = buf;
+        memcpy(p, prefix1, sizeof(prefix1) - 1); p += sizeof(prefix1) - 1;
+        memcpy(p, m->name, name_len); p += name_len;
+        memcpy(p, prefix2, sizeof(prefix2) - 1); p += sizeof(prefix2) - 1;
+        memcpy(p, m->source, m->source_len); p += m->source_len;
+        *p++ = '\n';
+        memcpy(p, prefix3, sizeof(prefix3) - 1); p += sizeof(prefix3) - 1;
+        memcpy(p, m->name, name_len); p += name_len;
+        memcpy(p, prefix4, sizeof(prefix4) - 1); p += sizeof(prefix4) - 1;
+        *p = '\0';
+        mp_runtime_exec(buf, p - buf);
+    }
+}


### PR DESCRIPTION
## Summary
- keep a persistent MicroPython runtime
- add loader for modules under `/mpymod`
- generate module table at build time
- call loader during boot
- automatically update Micropython during `build.sh`

## Testing
- `bash tests/test_fs.sh`
- `bash tests/test_mem.sh`
- `bash tests/test_ata_compile.sh`
- `bash tests/test_fatfs_compile.sh`
- `bash tests/full_kernel_test.sh` *(fails: grub packages missing)*


------
https://chatgpt.com/codex/tasks/task_e_6868be794b6483309db6689ebe4132d5