### PR TITLE
Kernel panic behavior update and MP stack fix

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -120,3 +120,5 @@
 - Removed obsolete example VGA MicroPython module causing build errors
 - Kernel automatically loads modules from /mpymod at boot using a persistent MicroPython runtime
 - Build script keeps the Micropython source up to date automatically
+- Fixed stack initialization for MicroPython runtime to prevent general protection faults
+- Kernel now halts on page fault exceptions instead of rebooting

--- a/kernel/idt.c
+++ b/kernel/idt.c
@@ -115,12 +115,7 @@ void idt_handle_interrupt(uint32_t num, uint32_t err, uint64_t rsp) {
         serial_uhex(err);
         serial_write("\n");
 
-        if (num == 14) {
-            console_puts("Press any key to reboot...\n");
-            serial_write("Press any key to reboot...\n");
-            wait_keypress();
-            reboot();
-        } else if (num == 3 || num == 1) {
+        if (num == 3 || num == 1) {
             return;
         } else {
             const char *type = current_user_app ? "User app" : "Kernel process";

--- a/kernel/micropython.c
+++ b/kernel/micropython.c
@@ -6,11 +6,12 @@
 
 static char mp_heap[64 * 1024];
 static int mp_active = 0;
-static int mp_stack_top;
+
 
 void mp_runtime_init(void) {
     if (!mp_active) {
-        mp_embed_init(mp_heap, sizeof(mp_heap), &mp_stack_top);
+        int stack_dummy;
+        mp_embed_init(mp_heap, sizeof(mp_heap), &stack_dummy);
         mp_active = 1;
     }
 }


### PR DESCRIPTION
## Summary
- fix MicroPython runtime stack initialization
- halt on page faults instead of rebooting
- update release notes

## Testing
- `yes 3 | ./build.sh iso`
- `tests/full_kernel_test.sh` *(failed: no boot log generated)*

------
https://chatgpt.com/codex/tasks/task_e_686a72f178e88330a878c911ee51635e