### PR TITLE
Implement Guru Meditation panic screen

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -122,3 +122,4 @@
 - Build script keeps the Micropython source up to date automatically
 - Fixed stack initialization for MicroPython runtime to prevent general protection faults
 - Kernel now halts on page fault exceptions instead of rebooting
+- Debug mode panics show a 'Guru Meditation' red screen

--- a/kernel/panic.c
+++ b/kernel/panic.c
@@ -6,6 +6,7 @@
 #include "panic.h"
 #include "serial.h"
 #include "debuglog.h"
+#include "runstate.h"
 
 
 extern volatile const char *current_program;
@@ -27,8 +28,15 @@ static void hexdump_file(FILE *f, const void *data, size_t len) {
 void panic_with_context(const char *msg, uint64_t rip, int user) {
     serial_init();
     debuglog_print_timestamp();
-    console_puts("Panic: ");
-    serial_write("Panic: ");
+    if (debug_mode) {
+        console_set_attr(VGA_WHITE, VGA_RED);
+        console_clear();
+        console_puts("Guru Meditation: Kernel Panic: ");
+        serial_write("Panic: ");
+    } else {
+        console_puts("Panic: ");
+        serial_write("Panic: ");
+    }
     console_puts(msg);
     serial_write(msg);
     console_putc('\n');


### PR DESCRIPTION
## Summary
- show a "Guru Meditation" message when kernel panics in debug mode
- update release notes

## Testing
- `./build.sh`

------
https://chatgpt.com/codex/tasks/task_e_686a7623751c83308b92e19919af97ee