### PR TITLE
Implement Guru Meditation panic screen

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -122,3 +122,6 @@
 - Build script keeps the Micropython source up to date automatically
 - Fixed stack initialization for MicroPython runtime to prevent general protection faults
 - Kernel now halts on page fault exceptions instead of rebooting
+- Debug mode panics show a 'Guru Meditation' red screen
+- Panics disable interrupts to avoid reboot loops
+- Freed memory is overwritten with 0xDEADBEEF when debug mode

--- a/include/mem.h
+++ b/include/mem.h
@@ -20,6 +20,7 @@ size_t mem_heap_free(void);
 /* Store arbitrary data for an application */
 int   mem_save_app(int app_id, const void *data, size_t size);
 void *mem_retrieve_app(int app_id, int handle, size_t *size);
+void mem_free(void *addr, size_t size);
 
 #ifdef __cplusplus
 }

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -326,5 +326,6 @@ void kernel_main(uint32_t magic, multiboot_info_t *mbi) {
     if (debug_mode) serial_write("All done, halting\n");
     debuglog_save_file();
     debuglog_flush();
+    __asm__ volatile("cli");
     for (;;) __asm__("hlt");
 }

--- a/kernel/mem.c
+++ b/kernel/mem.c
@@ -2,6 +2,7 @@
 #include "memutils.h"
 #include "console.h"
 #include "debuglog.h"
+#include "runstate.h"
 
 #define MAX_APPS 16
 
@@ -171,4 +172,18 @@ void *mem_retrieve_app(int app_id, int handle, size_t *size) {
         }
     }
     return NULL;
+}
+
+void mem_free(void *addr, size_t size) {
+    if (!addr || !size)
+        return;
+    if (debug_mode) {
+        uint32_t *p = addr;
+        size_t n = size / 4;
+        for (size_t i = 0; i < n; i++)
+            p[i] = 0xDEADBEEF;
+        uint8_t *b = (uint8_t *)addr;
+        for (size_t i = n * 4; i < size; i++)
+            b[i] = 0xEF;
+    }
 }

--- a/kernel/micropython.c
+++ b/kernel/micropython.c
@@ -31,6 +31,7 @@ void mp_runtime_exec(const char *code, size_t size) {
     memcpy(buf, code, size);
     buf[size] = '\0';
     mp_embed_exec_str(buf);
+    mem_free(buf, size + 1);
 }
 
 void mp_runtime_exec_mpy(const uint8_t *buf, size_t size) {

--- a/kernel/panic.c
+++ b/kernel/panic.c
@@ -6,6 +6,7 @@
 #include "panic.h"
 #include "serial.h"
 #include "debuglog.h"
+#include "runstate.h"
 
 
 extern volatile const char *current_program;
@@ -27,8 +28,15 @@ static void hexdump_file(FILE *f, const void *data, size_t len) {
 void panic_with_context(const char *msg, uint64_t rip, int user) {
     serial_init();
     debuglog_print_timestamp();
-    console_puts("Panic: ");
-    serial_write("Panic: ");
+    if (debug_mode) {
+        console_set_attr(VGA_WHITE, VGA_RED);
+        console_clear();
+        console_puts("Guru Meditation: Kernel Panic: ");
+        serial_write("Panic: ");
+    } else {
+        console_puts("Panic: ");
+        serial_write("Panic: ");
+    }
     console_puts(msg);
     serial_write(msg);
     console_putc('\n');
@@ -56,6 +64,7 @@ void panic_with_context(const char *msg, uint64_t rip, int user) {
 
     debuglog_flush();
     debuglog_dump_console();
+    __asm__ volatile("cli");
     for (;;) __asm__("hlt");
 }
 


### PR DESCRIPTION
## Summary
- show a "Guru Meditation" message when kernel panics in debug mode
- update release notes
- add mem_free to overwrite freed memory in debug mode
- disable interrupts before halting so panics don't loop
- free MicroPython buffers with mem_free

## Testing
- `printf "3\n" | ./build.sh > /tmp/build.log && tail -n 20 /tmp/build.log`


------
https://chatgpt.com/codex/tasks/task_e_686a7623751c83308b92e19919af97ee