### PR TITLE
Improve panic debug output and MP runtime

### DIFF
--- a/kernel/micropython.c
+++ b/kernel/micropython.c
@@ -3,6 +3,7 @@
 #include "mem.h"
 #include "port/micropython_embed.h"
 #include <string.h>
+#include "py/stackctrl.h"
 
 static char mp_heap[64 * 1024];
 static int mp_active = 0;
@@ -11,7 +12,9 @@ static int mp_active = 0;
 void mp_runtime_init(void) {
     if (!mp_active) {
         int stack_dummy;
+        mp_stack_ctrl_init();
         mp_embed_init(mp_heap, sizeof(mp_heap), &stack_dummy);
+        mp_stack_set_limit(16 * 1024);
         mp_active = 1;
     }
 }


### PR DESCRIPTION
## Summary
- show code bytes around crash on panic
- initialise MicroPython stack control to avoid GPF

## Testing
- `tests/test_ata_compile.sh`
- `tests/test_fatfs_compile.sh`
- `tests/test_mem.sh`
- `tests/test_fs.sh`


------
https://chatgpt.com/codex/tasks/task_e_686a7f8038a48330bff7e5ec6d20d825