### PR TITLE
Fix freed memory pattern for 64-bit systems

### DIFF
--- a/kernel/mem.c
+++ b/kernel/mem.c
@@ -178,12 +178,21 @@ void mem_free(void *addr, size_t size) {
     if (!addr || !size)
         return;
     if (debug_mode) {
+#if UINTPTR_MAX == 0xffffffff
         uint32_t *p = addr;
-        size_t n = size / 4;
+        size_t n = size / sizeof(uint32_t);
         for (size_t i = 0; i < n; i++)
             p[i] = 0xDEADBEEF;
+        size_t off = n * sizeof(uint32_t);
+#else
+        uint64_t *p = addr;
+        size_t n = size / sizeof(uint64_t);
+        for (size_t i = 0; i < n; i++)
+            p[i] = 0xDEADBEEFDEADBEEFULL;
+        size_t off = n * sizeof(uint64_t);
+#endif
         uint8_t *b = (uint8_t *)addr;
-        for (size_t i = n * 4; i < size; i++)
+        for (size_t i = off; i < size; i++)
             b[i] = 0xEF;
     }
 }


### PR DESCRIPTION
## Summary
- ensure memory is overwritten with a 64‑bit `0xDEADBEEFDEADBEEF` pattern when freeing on 64‑bit builds
- keep the 32‑bit fill for 32‑bit targets

## Testing
- `bash tests/test_mem.sh`

------
https://chatgpt.com/codex/tasks/task_e_686b524f691083308908d1f1b6dc773a