### PR TITLE
Handle builtin modules when no boot modules

### DIFF
--- a/kernel/main.c
+++ b/kernel/main.c
@@ -139,7 +139,7 @@ void kernel_main(uint32_t magic, multiboot_info_t *mbi) {
     console_udec(mbi->mods_count);
     console_putc('\n');
     serial_write("\n");
-    if (mbi->mods_count == 0) {
+    if (mbi->mods_count == 0 && mpymod_table_count == 0) {
         panic("No modules found");
     }
 


### PR DESCRIPTION
## Summary
- avoid panic when no modules are passed but builtin `mpymod` modules exist

## Testing
- `tests/test_fatfs_compile.sh`
- `tests/test_ata_compile.sh`
- `tests/test_fs.sh`
- `tests/full_kernel_test.sh` *(fails: QEMU build/boot restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_686d276e04ac8330bbb5003adab0d5e9