### PR TITLE
Refine init search and add strstr

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -129,3 +129,6 @@
 - Freed memory is overwritten with 0xDEADBEEF when debug mode
 - Build number tracking moved to `build.txt` with automatic reset on major updates
 - Build script optionally stores GitHub credentials via `GITHUB_USER` and `GITHUB_TOKEN`
+\n- Kernel boots by running init from init/kernel/init.py. Module loader removed.
+- Boot now searches only for raw init/kernel/init.py and no longer accepts .mpy files
+- Added internal strstr implementation to fix missing symbol during linking

--- a/include/config.h
+++ b/include/config.h
@@ -2,7 +2,7 @@
 #define EXOCORE_CONFIG_H
 
 /* Enable run-directory modules */
-#define FEATURE_RUN_DIR 1
+#define FEATURE_RUN_DIR 0
 
 /* Fixed load address for all modules */
 #define MODULE_BASE_ADDR 0x00200000

--- a/include/memutils.h
+++ b/include/memutils.h
@@ -14,6 +14,7 @@ size_t strlen(const char *s);
 void *memmove(void *dst, const void *src, size_t n);
 int memcmp(const void *s1, const void *s2, size_t n);
 char *strchr(const char *s, int c);
+char *strstr(const char *haystack, const char *needle);
 void __assert_fail(const char *expr, const char *file, unsigned int line, const char *func);
 void *__memcpy_chk(void *dest, const void *src, size_t n, size_t destlen);
 

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -15,7 +15,6 @@
 #include "runstate.h"
 #include "script.h"
 #include "micropython.h"
-#include "mpy_loader.h"
 #include "buildinfo.h"
 
 int debug_mode = 0;
@@ -134,17 +133,14 @@ void kernel_main(uint32_t magic, multiboot_info_t *mbi) {
     }
 
     /* 4) Module count */
-    serial_write("mods_count="); console_puts("mods_count=");
-    // we want decimal printing, reuse console_udec
+    serial_write("mods_count=");
+    console_puts("mods_count=");
     console_udec(mbi->mods_count);
     console_putc('\n');
     serial_write("\n");
-    if (mbi->mods_count == 0 && mpymod_table_count == 0) {
+    if (mbi->mods_count == 0) {
         panic("No modules found");
     }
-
-    mp_runtime_init();
-    mpymod_load_all();
 
 #if FEATURE_RUN_DIR
     /* 5) Load & execute modules. Modules are linked to run at
@@ -319,7 +315,25 @@ void kernel_main(uint32_t magic, multiboot_info_t *mbi) {
     }
     mp_runtime_deinit();
 #else
-    console_puts("FEATURE_RUN_DIR disabled\n");
+    multiboot_module_t *mods = (multiboot_module_t*)(uintptr_t)mbi->mods_addr;
+    const uint8_t *init_src = NULL;
+    uint32_t init_size = 0;
+    for (uint32_t i = 0; i < mbi->mods_count; i++) {
+        const char *name = (const char*)(uintptr_t)mods[i].string;
+        if (name && strstr(name, "init/kernel/init.py")) {
+            init_src = (const uint8_t*)(uintptr_t)mods[i].mod_start;
+            init_size = mods[i].mod_end - mods[i].mod_start;
+            break;
+        }
+    }
+    if (!init_src) {
+        console_puts("init not found!\n");
+        panic("init not found");
+    }
+    console_puts("run init as init\n");
+    mp_runtime_init();
+    mp_runtime_exec((const char*)init_src, init_size);
+    mp_runtime_deinit();
 #endif
 
     console_puts("All done, halting\n");

--- a/kernel/memutils.c
+++ b/kernel/memutils.c
@@ -70,6 +70,20 @@ char *strchr(const char *s, int c) {
     return NULL;
 }
 
+char *strstr(const char *haystack, const char *needle) {
+    if (!*needle) return (char*)haystack;
+    for (; *haystack; haystack++) {
+        const char *h = haystack;
+        const char *n = needle;
+        while (*h && *n && *h == *n) {
+            h++; n++;
+        }
+        if (!*n)
+            return (char*)haystack;
+    }
+    return NULL;
+}
+
 void __assert_fail(const char *expr, const char *file, unsigned int line, const char *func) {
     (void)expr; (void)file; (void)line; (void)func;
     for (;;)


### PR DESCRIPTION
## Summary
- add internal `strstr` to memutils
- stop looking for `.mpy` init files; use raw `.py`
- remove leftover `<string.h>` include
- document new boot rule and `strstr` fix

## Testing
- `bash tests/test_fs.sh`
- `bash tests/test_mem.sh`
- `bash tests/full_kernel_test.sh` *(fails: grub-mkrescue missing)*

------
https://chatgpt.com/codex/tasks/task_e_686d3063fdd083308979e8846c6346d2