### PR TITLE
Fix missing init packaging

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -439,6 +439,14 @@ for m in "${USER_MODULES[@]}"; do
   USER_MODULES_BN+=( "$bn" )
 done
 
+# include init script if present
+INIT_SCRIPT="init/kernel/init.py"
+if [ -f "$INIT_SCRIPT" ]; then
+  mkdir -p isodir/boot/init/kernel
+  cp "$INIT_SCRIPT" isodir/boot/init/kernel/init.py
+  MODULES+=( "init/kernel/init.py" )
+fi
+
 # 12) Generate grub.cfg
 cat > isodir/boot/grub/grub.cfg << EOF
 set timeout=5

--- a/init/kernel/init.py
+++ b/init/kernel/init.py
@@ -1,1 +1,2 @@
-print("This is a placeholder. replace with whatever code youd like :)")
+print("ExoCore init starting")
+print("MicroPython environment ready")


### PR DESCRIPTION
## Summary
- copy `init/kernel/init.py` when building ISO so the kernel can find init
- replace placeholder init script with a small message

## Testing
- `./tests/test_mem.sh`
- `./tests/test_fs.sh`
- `./tests/full_kernel_test.sh` *(fails: grub-mkrescue not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686d37536c5c8330b5d1f952fdee7f41