### PR TITLE
Fix init search in grub config

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -439,6 +439,14 @@ for m in "${USER_MODULES[@]}"; do
   USER_MODULES_BN+=( "$bn" )
 done
 
+# include init script if present
+INIT_SCRIPT="init/kernel/init.py"
+if [ -f "$INIT_SCRIPT" ]; then
+  mkdir -p isodir/boot/init/kernel
+  cp "$INIT_SCRIPT" isodir/boot/init/kernel/init.py
+  MODULES+=( "init/kernel/init.py" )
+fi
+
 # 12) Generate grub.cfg
 cat > isodir/boot/grub/grub.cfg << EOF
 set timeout=5
@@ -449,7 +457,7 @@ menuentry "ExoCore Alpha" {
 EOF
 
 for mod in "${MODULES[@]}"; do
-  echo "  module /boot/$mod" >> isodir/boot/grub/grub.cfg
+  echo "  module /boot/$mod $mod" >> isodir/boot/grub/grub.cfg
 done
 cat >> isodir/boot/grub/grub.cfg << EOF
   boot
@@ -459,7 +467,7 @@ menuentry "ExoCore-Kernel (Debug)" {
   multiboot /boot/kernel.bin debug
 EOF
 for mod in "${MODULES[@]}"; do
-  echo "  module /boot/$mod" >> isodir/boot/grub/grub.cfg
+  echo "  module /boot/$mod $mod" >> isodir/boot/grub/grub.cfg
 done
 cat >> isodir/boot/grub/grub.cfg << EOF
   boot

--- a/init/kernel/init.py
+++ b/init/kernel/init.py
@@ -1,1 +1,2 @@
-print("This is a placeholder. replace with whatever code youd like :)")
+print("ExoCore init starting")
+print("MicroPython environment ready")

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -332,9 +332,7 @@ void kernel_main(uint32_t magic, multiboot_info_t *mbi) {
         panic("init not found");
     }
     console_puts("run init as init\n");
-    mp_runtime_init();
     mp_runtime_exec((const char*)init_src, init_size);
-    mp_runtime_deinit();
 #endif
 
     console_puts("All done, halting\n");


### PR DESCRIPTION
## Summary
- pass module path as argument in grub.cfg so kernel can locate init
- remove duplicate micropython initialization

## Testing
- `./tests/test_mem.sh`
- `./tests/test_fs.sh`
- `./tests/full_kernel_test.sh` *(fails: micropython build output only)*

------
https://chatgpt.com/codex/tasks/task_e_686d37536c5c8330b5d1f952fdee7f41