### PR TITLE
Remove unused architectures from build

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -27,6 +27,8 @@
 - Kernel prints module addresses and entry points in hex
 - Modules build with `-m64` when using the x86_64 toolchain
 - Modules now link against a serial stub for debugging output
+- Removed unsupported architectures from the build script; only native and
+  x86_64 cross-compilation remain
 
 ## New Features
 - Example `memtest` module using new API

--- a/build.sh
+++ b/build.sh
@@ -141,12 +141,8 @@ fi
 # 1) Target selection & tool fallback installer
 echo "Select target architecture, comma-separated choices:"
 echo " 1) native (host)"
-echo " 2) i686-elf (x86)"
-echo " 3) x86_64-elf (AMD64)"
-echo " 4) arm-none-eabi (ARM)"
-echo " 5) aarch64-linux-gnu (ARM64)"
-echo " 6) riscv64-unknown-elf (RISC-V)"
-read -p "Enter choice [1-6]: " arch_choice
+echo " 2) x86_64-elf (AMD64)"
+read -p "Enter choice [1-2]: " arch_choice
 
 # Module load address must match MODULE_BASE_ADDR in include/config.h
 MODULE_BASE=0x00200000
@@ -156,26 +152,14 @@ case "$arch_choice" in
     CC=gcc; LD=ld; ARCH_FLAG=-m64; LDARCH="elf_x86_64";
     QEMU=qemu-system-x86_64; FALLBACK_PKG="build-essential" ;;
   2)
-    CC=i686-linux-gnu-gcc; LD=i686-linux-gnu-ld; ARCH_FLAG=-m32; LDARCH="elf_i386";
-    QEMU=qemu-system-i386; FALLBACK_PKG="binutils-i686-linux-gnu gcc-i686-linux-gnu" ;;
-  3)
     CC=x86_64-linux-gnu-gcc; LD=x86_64-linux-gnu-ld; ARCH_FLAG=-m64; LDARCH="elf_x86_64";
     QEMU=qemu-system-x86_64; FALLBACK_PKG="binutils-x86-64-linux-gnu gcc-x86-64-linux-gnu" ;;
-  4)
-    CC=arm-none-eabi-gcc; LD=arm-none-eabi-ld; ARCH_FLAG=""; LDARCH="armelf";
-    QEMU=qemu-system-arm; FALLBACK_PKG="binutils-arm-none-eabi gcc-arm-none-eabi" ;;
-  5)
-    CC=aarch64-linux-gnu-gcc; LD=aarch64-linux-gnu-ld; ARCH_FLAG=""; LDARCH="aarch64linux";
-    QEMU=qemu-system-aarch64; FALLBACK_PKG="binutils-aarch64-linux-gnu gcc-aarch64-linux-gnu" ;;
-  6)
-    CC=riscv64-unknown-elf-gcc; LD=riscv64-unknown-elf-ld; ARCH_FLAG=""; LDARCH="elf64-littleriscv";
-    QEMU=qemu-system-riscv64; FALLBACK_PKG="binutils-riscv64-unknown-elf gcc-riscv64-unknown-elf" ;;
   *) echo "Invalid choice, bro."; exit 1 ;;
 esac
 
 # Use 64-bit objects for modules when the x86_64 toolchain is selected
 MODULE_FLAG="$ARCH_FLAG"
-if [ "$arch_choice" = "3" ]; then
+if [ "$arch_choice" = "2" ]; then
   MODULE_FLAG="-m64"
 fi
 


### PR DESCRIPTION
## Summary
- keep only native and x86_64 options in `build.sh`
- document removal of other architectures in release notes

## Testing
- `./build.sh <<'EOF'
1
EOF`
- `./build.sh <<'EOF'
2
EOF`


------
https://chatgpt.com/codex/tasks/task_e_686deca2e1688330a433035981c48ab6