### PR TITLE
Restore mpymod loader

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -136,3 +136,4 @@
 - Boot now searches only for raw init/kernel/init.py and no longer accepts .mpy files
 - Added internal strstr implementation to fix missing symbol during linking
 
+- Reintroduced mpymod loader executing init.py from each module

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -331,6 +331,8 @@ void kernel_main(uint32_t magic, multiboot_info_t *mbi) {
         console_puts("init not found!\n");
         panic("init not found");
     }
+    mp_runtime_init();
+    mpymod_load_all();
     console_puts("run init as init\n");
     mp_runtime_exec((const char*)init_src, init_size);
 #endif

--- a/kernel/micropython.c
+++ b/kernel/micropython.c
@@ -15,6 +15,30 @@ void mp_runtime_init(void) {
         mp_stack_ctrl_init();
         mp_embed_init(mp_heap, sizeof(mp_heap), &stack_dummy);
         mp_stack_set_limit(16 * 1024);
+        /* expose environment and helper modules */
+        mp_embed_exec_str(
+            "import builtins, types\n"
+            "env = {}\n"
+            "_mpymod_data = {}\n"
+            "class _C:\n"
+            "    def exec(self, *args):\n"
+            "        print('c.exec', args)\n"
+            "c = _C()\n"
+            "def mpyrun(name, *args):\n"
+            "    src = _mpymod_data.get(name)\n"
+            "    if src is None:\n"
+            "        print('module not found', name)\n"
+            "        return\n"
+            "    ns = {'env': env, 'mpyrun': mpyrun, 'c': c, '__name__': name}\n"
+            "    exec(src, ns)\n"
+            "builtins.env = env\n"
+            "builtins.mpyrun = mpyrun\n"
+            "builtins.c = c\n"
+            "builtins._mpymod_data = _mpymod_data\n"
+            "import sys\n"
+            "sys.modules['env'] = types.ModuleType('env')\n"
+            "sys.modules['env'].env = env\n"
+        );
         mp_active = 1;
     }
 }

--- a/kernel/mpy_loader.c
+++ b/kernel/mpy_loader.c
@@ -6,27 +6,32 @@
 void mpymod_load_all(void) {
     for (size_t i = 0; i < mpymod_table_count; ++i) {
         const mpymod_entry_t *m = &mpymod_table[i];
-        const char prefix1[] = "import sys, types\nmod = types.ModuleType('";
-        const char prefix2[] = "')\nexec(\"\"\"\n";
-        const char prefix3[] = "\"\", mod.__dict__)\nsys.modules['";
-        const char prefix4[] = "'] = mod\n";
         size_t name_len = strlen(m->name);
-        size_t total = sizeof(prefix1) - 1 + name_len +
-                       sizeof(prefix2) - 1 + m->source_len + 1 +
-                       sizeof(prefix3) - 1 + name_len + sizeof(prefix4) - 1;
-        char *buf = mem_alloc(total + 1);
+        /* escape special characters for Python string */
+        size_t esc_len = 0;
+        for (size_t j = 0; j < m->source_len; ++j) {
+            char c = m->source[j];
+            if (c == '\\' || c == '"') esc_len++; /* extra backslash */
+        }
+        size_t total = name_len * 2 + m->source_len + esc_len + 128;
+        char *buf = mem_alloc(total);
         if (!buf)
             continue;
         char *p = buf;
-        memcpy(p, prefix1, sizeof(prefix1) - 1); p += sizeof(prefix1) - 1;
+        memcpy(p, "import builtins\n", 16); p += 16;
+        memcpy(p, "builtins._mpymod_data['", 23); p += 23;
         memcpy(p, m->name, name_len); p += name_len;
-        memcpy(p, prefix2, sizeof(prefix2) - 1); p += sizeof(prefix2) - 1;
-        memcpy(p, m->source, m->source_len); p += m->source_len;
-        *p++ = '\n';
-        memcpy(p, prefix3, sizeof(prefix3) - 1); p += sizeof(prefix3) - 1;
+        memcpy(p, "'] = \"", 6); p += 6;
+        for (size_t j = 0; j < m->source_len; ++j) {
+            char c = m->source[j];
+            if (c == '\\' || c == '"') *p++ = '\\';
+            *p++ = c;
+        }
+        memcpy(p, "\"\nbuiltins.mpyrun('", 20); p += 20;
         memcpy(p, m->name, name_len); p += name_len;
-        memcpy(p, prefix4, sizeof(prefix4) - 1); p += sizeof(prefix4) - 1;
+        memcpy(p, "')\n", 3); p += 3;
         *p = '\0';
         mp_runtime_exec(buf, p - buf);
+        mem_free(buf, total);
     }
 }

--- a/mpymod/vga/init.py
+++ b/mpymod/vga/init.py
@@ -1,0 +1,3 @@
+print("vga module loaded")
+from env import env
+env['vga'] = True

--- a/mpymod/vga_demo/init.py
+++ b/mpymod/vga_demo/init.py
@@ -1,0 +1,5 @@
+print("vga_demo starting")
+from env import env
+import vga
+vga.enable(True)
+env['vga_demo'] = 'enabled'


### PR DESCRIPTION
## Summary
- restore loader for modules under `mpymod`
- allow MicroPython runtime to provide `env`, `mpyrun` and `c` helpers
- load modules from `mpymod` at boot and run their `init.py`
- add example init files for existing modules
- regenerate release notes

## Testing
- `tests/test_mem.sh`
- `tests/test_fs.sh`
- `tests/test_ata_compile.sh`
- `tests/test_fatfs_compile.sh`
- `tests/full_kernel_test.sh`

------
https://chatgpt.com/codex/tasks/task_e_686df5df0cd4833093be883f509871a6