### PR TITLE
Fix mpymod native build and update notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -138,4 +138,5 @@
 
 - Reintroduced mpymod loader executing init.py from each module
 - Documented how to create and use custom mpymod modules
+- Fixed mpymod native build by adding missing MicroPython include paths
 

--- a/build.sh
+++ b/build.sh
@@ -368,7 +368,9 @@ for dir in mpymod/*; do
       [ -f "$cfile" ] || continue
       obj="$MP_BUILD/$(basename "${mod_name}_$(basename "${cfile%.c}").o")"
       echo "Compiling mpymod native $cfile → $obj"
-      $CC $ARCH_FLAG -std=gnu99 -ffreestanding -O2 $STACK_FLAGS -Iinclude -c "$cfile" -o "$obj"
+      $CC $ARCH_FLAG -std=gnu99 -ffreestanding -O2 $STACK_FLAGS \
+          -Iinclude -I"$MP_DIR" -I"$MP_DIR/examples/embedding" \
+          -I"$MP_SRC" -I"$MP_SRC/port" -c "$cfile" -o "$obj"
       MP_OBJS+=("$obj")
     done
   fi


### PR DESCRIPTION
## Summary
- add Micropython include paths when compiling mpymod native sources
- document the build fix in release notes

## Testing
- `bash tests/test_ata_compile.sh`
- `bash tests/test_fatfs_compile.sh`
- `bash tests/test_fs.sh`
- `bash tests/test_mem.sh`
- `bash tests/full_kernel_test.sh` *(fails: apt packages unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_686dfe92b30483308bdf7e87db7e1d83