### PR TITLE
Add ELF init support and remove mpymod loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 * Simple memory-backed filesystem driver that can mount, read, and write storage
 * FAT filesystem driver for real disks with bad sector detection
 * Basic ATA PIO driver for block storage access
-* Kernel-integrated MicroPython loader executes `init.py` from each `/mpymod` folder at boot ([docs](docs/Kernel-Integrated-Module-Loader.md))
+* Init process can be `init/kernel/init.py` or `init/kernel/init.elf`
 
 ## Prerequisites
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -141,4 +141,5 @@
 - Fixed mpymod native build by adding missing MicroPython include paths
 - mpymod loader now stores scripts in the `env` module so boot doesn't fail when
   builtins are read-only
+- Removed MicroPython mpymod loader again and added support for init/kernel/init.elf
 


### PR DESCRIPTION
## Summary
- remove mpymod loader includes and calls
- support `init/kernel/init.elf` or `init/kernel/init.py`
- drop mpymod data build steps
- update docs and release notes

## Testing
- `tests/test_mem.sh`
- `tests/test_fatfs_compile.sh`
- `tests/test_ata_compile.sh`


------
https://chatgpt.com/codex/tasks/task_e_6873ba6084c48330bd57bf6d8e9fba2b