### PR TITLE
Add execo loader for MicroPython modules

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -392,6 +392,8 @@ $CC $ARCH_FLAG -std=gnu99 -ffreestanding -O2 $STACK_FLAGS -fcf-protection=none -
 $CC $ARCH_FLAG -std=gnu99 -ffreestanding -O2 $STACK_FLAGS -fcf-protection=none -Wall -U__linux__ -Iinclude \
     -c kernel/debuglog.c -o kernel/debuglog.o
 $CC $ARCH_FLAG -std=gnu99 -ffreestanding -O2 $STACK_FLAGS -fcf-protection=none -Wall -U__linux__ -Iinclude \
+    -c kernel/modexec.c -o kernel/modexec.o
+$CC $ARCH_FLAG -std=gnu99 -ffreestanding -O2 $STACK_FLAGS -fcf-protection=none -Wall -U__linux__ -Iinclude \
     -c linkdep/io.c -o kernel/io.o
 # 9) Link into flat kernel.bin
 echo "Linking kernel.bin..."
@@ -399,7 +401,7 @@ $LD -m $LDARCH -T linker.ld \
     arch/x86/boot.o arch/x86/idt.o \
     kernel/main.o kernel/mem.o kernel/console.o kernel/serial.o \
     kernel/idt.o kernel/panic.o kernel/memutils.o kernel/fs.o kernel/script.o \
-    kernel/debuglog.o kernel/micropython.o ${MP_OBJS[@]} kernel/io.o \
+    kernel/debuglog.o kernel/micropython.o kernel/modexec.o ${MP_OBJS[@]} kernel/io.o \
     -o kernel.bin
 
 # 10) Prepare ISO tree

--- a/include/modexec.h
+++ b/include/modexec.h
@@ -1,0 +1,13 @@
+#ifndef MODEXEC_H
+#define MODEXEC_H
+#include <stdint.h>
+#ifdef __cplusplus
+extern "C" {
+#endif
+struct multiboot_info;
+void modexec_set_mbi(struct multiboot_info *mbi);
+int modexec_run(const char *name);
+#ifdef __cplusplus
+}
+#endif
+#endif /* MODEXEC_H */

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -15,6 +15,7 @@
 #include "runstate.h"
 #include "script.h"
 #include "micropython.h"
+#include "modexec.h"
 #include "buildinfo.h"
 #include <string.h>
 
@@ -57,6 +58,7 @@ void kernel_main(uint32_t magic, multiboot_info_t *mbi) {
     console_init();
     debuglog_print_timestamp();
     dbg_puts("console_init done\n");
+    modexec_set_mbi(mbi);
     debuglog_print_timestamp();
     dbg_puts("GRUB handed control to kernel\n");
     if (debug_mode) {

--- a/kernel/micropython.c
+++ b/kernel/micropython.c
@@ -2,6 +2,7 @@
 #include "console.h"
 #include "mem.h"
 #include "port/micropython_embed.h"
+#include "modexec.h"
 #include <string.h>
 #include "py/stackctrl.h"
 #include "py/objmodule.h"
@@ -9,6 +10,13 @@
 
 static char mp_heap[64 * 1024];
 static int mp_active = 0;
+
+STATIC mp_obj_t mp_c_execo(mp_obj_t path_obj) {
+    const char *path = mp_obj_str_get_str(path_obj);
+    modexec_run(path);
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(mp_c_execo_obj, mp_c_execo);
 
 
 void mp_runtime_init(void) {
@@ -29,14 +37,18 @@ void mp_runtime_init(void) {
         mp_obj_t env_dict = mp_obj_new_dict(0);
         mp_obj_dict_store(env_globals, mp_obj_new_str("env", 3), env_dict);
 
+        /* create built-in 'c' module with execo() */
+        mp_obj_dict_t *c_globals = mp_obj_new_dict(0);
+        mp_obj_dict_store(c_globals, mp_obj_new_str("execo", 6), MP_OBJ_FROM_PTR(&mp_c_execo_obj));
+        mp_obj_module_t *c_mod = m_new_obj(mp_obj_module_t);
+        c_mod->base.type = &mp_type_module;
+        c_mod->globals = c_globals;
+        mp_obj_dict_store(MP_OBJ_FROM_PTR(&MP_STATE_VM(mp_loaded_modules_dict)), mp_obj_new_str("c", 1), MP_OBJ_FROM_PTR(c_mod));
+
         /* expose helper functions via Python stub */
         mp_embed_exec_str(
-            "import sys, env\n"
+            "import sys, env, c\n"
             "_mpymod_data = {}\n"
-            "class _C:\n"
-            "    def exec(self, *args):\n"
-            "        print('c.exec', args)\n"
-            "c = _C()\n"
             "def mpyrun(name, *args):\n"
             "    src = _mpymod_data.get(name)\n"
             "    if src is None:\n"

--- a/kernel/modexec.c
+++ b/kernel/modexec.c
@@ -1,0 +1,34 @@
+#include "modexec.h"
+#include "mem.h"
+#include "console.h"
+#include "config.h"
+#include "multiboot.h"
+#include <string.h>
+
+static multiboot_info_t *g_mbi = NULL;
+
+void modexec_set_mbi(multiboot_info_t *mbi) {
+    g_mbi = mbi;
+}
+
+int modexec_run(const char *name) {
+    if (!g_mbi) return -1;
+    multiboot_module_t *mods = (multiboot_module_t*)(uintptr_t)g_mbi->mods_addr;
+    for (uint32_t i = 0; i < g_mbi->mods_count; ++i) {
+        const char *mstr = (const char*)(uintptr_t)mods[i].string;
+        if (mstr && strcmp(mstr, name) == 0) {
+            uint8_t *src  = (uint8_t*)(uintptr_t)mods[i].mod_start;
+            uint32_t size = mods[i].mod_end - mods[i].mod_start;
+            uint8_t *base = (uint8_t*)MODULE_BASE_ADDR;
+            memcpy(base, src, size);
+            console_puts("exec.o ");
+            console_puts(name);
+            console_putc('\n');
+            void (*entry)(void) = (void(*)(void))base;
+            entry();
+            return 0;
+        }
+    }
+    console_puts("exec.o failed: not found\n");
+    return -1;
+}


### PR DESCRIPTION
## Summary
- allow MicroPython code to execute preloaded `.o` modules
- expose new `c.execo()` function
- keep pointer to multiboot info for module execution
- compile `modexec.c` as part of the kernel build

## Testing
- `./tests/test_mem.sh`
- `./tests/test_fs.sh`
- `./tests/test_ata_compile.sh`


------
https://chatgpt.com/codex/tasks/task_e_6873c3eaeb90833088898acac38183fe