### PR TITLE
Fix build issues for QEMU boot

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -143,3 +143,4 @@
   builtins are read-only
 - Removed MicroPython mpymod loader again and added support for init/kernel/init.elf
 
+- Fixed build failures due to missing STATIC macro and multiboot type mismatch

--- a/include/modexec.h
+++ b/include/modexec.h
@@ -1,11 +1,11 @@
 #ifndef MODEXEC_H
 #define MODEXEC_H
 #include <stdint.h>
+#include "multiboot.h"
 #ifdef __cplusplus
 extern "C" {
 #endif
-struct multiboot_info;
-void modexec_set_mbi(struct multiboot_info *mbi);
+void modexec_set_mbi(multiboot_info_t *mbi);
 int modexec_run(const char *name);
 #ifdef __cplusplus
 }

--- a/kernel/micropython.c
+++ b/kernel/micropython.c
@@ -8,6 +8,10 @@
 #include "py/objmodule.h"
 #include "py/runtime.h"
 
+#ifndef STATIC
+#define STATIC static
+#endif
+
 static char mp_heap[64 * 1024];
 static int mp_active = 0;
 


### PR DESCRIPTION
## Summary
- add fallback STATIC definition for MicroPython build
- clean up multiboot header usage for modexec
- document build fix in release notes

## Testing
- `printf '2\n' | ./build.sh > build.log`
- `printf '2\n' | ./build.sh run nographic`

------
https://chatgpt.com/codex/tasks/task_e_6873ce06879483308d4a61b5bb2726bf