### PR TITLE
Add mpymod build integration and VGA module test

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -360,6 +360,18 @@ while IFS= read -r -d '' src; do
 done < <(find "$MP_SRC" -name '*.c' -print0)
 $CC $ARCH_FLAG -std=gnu99 -ffreestanding -O2 $STACK_FLAGS -Iinclude -I"$MP_DIR/examples/embedding" -I"$MP_SRC" -I"$MP_SRC/port" -c kernel/micropython.c -o kernel/micropython.o
 
+# Compile all custom C modules under mpymod into MicroPython
+for modfile in mpymod/*/native/*.c; do
+  [ -f "$modfile" ] || continue
+  modbase=$(basename "$modfile" .c)
+  modobj="$MP_BUILD/${modbase}.o"
+  echo "Compiling custom MicroPython module $modfile → $modobj"
+  $CC $ARCH_FLAG -std=gnu99 -ffreestanding -O2 $STACK_FLAGS \
+      -Iinclude -I"$MP_DIR/examples/embedding" -I"$MP_SRC" -I"$MP_SRC/port" \
+      -c "$modfile" -o "$modobj"
+  MP_OBJS+=("$modobj")
+done
+
 
 # 8) Compile & assemble the kernel
 echo "Compiling kernel..."

--- a/init/kernel/init.py
+++ b/init/kernel/init.py
@@ -1,2 +1,10 @@
 print("ExoCore init starting")
 print("MicroPython environment ready")
+
+try:
+    import vga
+    print("Testing VGA module...")
+    vga.enable(True)
+    print("VGA module call succeeded")
+except Exception as e:
+    print("VGA module test failed:", e)


### PR DESCRIPTION
## Summary
- compile custom C modules in `mpymod` when building MicroPython
- test the VGA module from `init/kernel/init.py`

## Testing
- `./tests/test_ata_compile.sh`
- `./tests/test_fatfs_compile.sh`
- `./tests/test_mem.sh`
- `./tests/test_fs.sh`


------
https://chatgpt.com/codex/tasks/task_e_6874b9950330833094f56a7614ce9294