### PR TITLE
Add usermod build step

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -123,15 +123,40 @@ mp_uint_t mp_hal_stderr_tx_strn(const char *str, size_t len) {
 }
 EOF
 
-# rebuild embed port to include patched mphalport.c
+# Prepare MicroPython user modules before rebuilding the embed port
+USERMOD_DST="$MP_DIR/examples/embedding/micropython_embed/usermod"
+if [ -d "$USERMOD_DST" ]; then
+  find "$USERMOD_DST" -maxdepth 1 -type f \( -name '*.c' -o -name '*.h' \) -exec rm -f {} +
+else
+  mkdir -p "$USERMOD_DST"
+fi
+
+USERMOD_FILES=()
+for native_dir in mpymod/*/native; do
+  [ -d "$native_dir" ] || continue
+  for src in "$native_dir"/*.c "$native_dir"/*.h; do
+    [ -f "$src" ] || continue
+    cp "$src" "$USERMOD_DST/"
+    USERMOD_FILES+=("$src")
+  done
+done
+
+MAKE_USERMOD_ARGS=""
+if [ ${#USERMOD_FILES[@]} -gt 0 ]; then
+  MAKE_USERMOD_ARGS="USERMOD_DIR=examples/embedding/micropython_embed/usermod"
+else
+  echo "No usermod sources found, building without USERMOD_DIR"
+fi
+
+# rebuild embed port to include patched mphalport.c and any user modules
 rm -rf "$MP_DIR/examples/embedding/build-embed"
-make -C "$MP_DIR/examples/embedding" -f micropython_embed.mk
+make -C "$MP_DIR/examples/embedding" -f micropython_embed.mk $MAKE_USERMOD_ARGS
 
 # ensure qstr for built-in VGA module
 if ! grep -q "^Q(vga)$" "$MP_DIR/examples/embedding/micropython_embed/py/qstrdefs.h"; then
   echo "Q(vga)" >> "$MP_DIR/examples/embedding/micropython_embed/py/qstrdefs.h"
   rm -rf "$MP_DIR/examples/embedding/build-embed"
-  make -C "$MP_DIR/examples/embedding" -f micropython_embed.mk
+  make -C "$MP_DIR/examples/embedding" -f micropython_embed.mk $MAKE_USERMOD_ARGS
 fi
 
 # Previously an example VGA control module was injected here. It


### PR DESCRIPTION
## Summary
- build.sh: copy .c and .h files from `mpymod/*/native` into MicroPython's embed usermod directory before building
- rebuild embed port with USERMOD_DIR if custom sources exist

## Testing
- `./tests/test_ata_compile.sh`
- `./tests/test_fatfs_compile.sh`
- `./tests/test_fs.sh`
- `./tests/test_mem.sh`


------
https://chatgpt.com/codex/tasks/task_e_6874cbac3d64833099f6b09541e835c5