### PR TITLE
Add update script for kernel and MicroPython

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -29,6 +29,7 @@
 - Modules now link against a serial stub for debugging output
 - Removed unsupported architectures from the build script; only native and
   x86_64 cross-compilation remain
+- `update.sh` script updates kernel and MicroPython sources individually or together
 
 ## New Features
 - Example `memtest` module using new API

--- a/update.sh
+++ b/update.sh
@@ -1,9 +1,37 @@
 #!/usr/bin/env bash
 set -e
 
-show_usage() {
-  echo "Usage: $0 [--kernel|-k] [--mpy|-m] [--all|-a]"
-  echo "Without arguments a menu is shown to choose what to update."
+usage() {
+  cat <<'EOT'
+Usage: $0 [--kernel|-k] [--mpy|-m] [--both|-b]
+Without arguments a menu is shown to choose what to update.
+EOT
+}
+
+update_kernel() {
+  echo "Updating kernel repository..."
+  if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    local remote
+    remote=$(git remote | head -n1)
+    if [ -n "$remote" ]; then
+      git pull "$remote"
+    else
+      echo "No remote found; skipping."
+    fi
+  else
+    echo "Not inside a git repository; skipping."
+  fi
+}
+
+update_mpy() {
+  local dir="micropython"
+  if [ ! -d "$dir" ]; then
+    echo "Cloning Micropython repository..."
+    git clone --depth 1 https://github.com/micropython/micropython.git "$dir"
+  else
+    echo "Updating Micropython repository..."
+    (cd "$dir" && git pull)
+  fi
 }
 
 UPDATE_KERNEL=false
@@ -12,25 +40,11 @@ UPDATE_MPY=false
 if [ $# -gt 0 ]; then
   for arg in "$@"; do
     case "$arg" in
-      --kernel|-k)
-        UPDATE_KERNEL=true
-        ;;
-      --mpy|-m)
-        UPDATE_MPY=true
-        ;;
-      --all|-a)
-        UPDATE_KERNEL=true
-        UPDATE_MPY=true
-        ;;
-      -h|--help)
-        show_usage
-        exit 0
-        ;;
-      *)
-        echo "Unknown option: $arg"
-        show_usage
-        exit 1
-        ;;
+      --kernel|-k) UPDATE_KERNEL=true ;;
+      --mpy|-m) UPDATE_MPY=true ;;
+      --both|-b|--all|-a) UPDATE_KERNEL=true; UPDATE_MPY=true ;;
+      -h|--help) usage; exit 0 ;;
+      *) echo "Unknown option: $arg"; usage; exit 1 ;;
     esac
   done
 else
@@ -48,24 +62,6 @@ else
   esac
 fi
 
-if $UPDATE_KERNEL; then
-  echo "Updating kernel repository..."
-  if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-    REMOTE=$(git remote | head -n1)
-    if [ -n "$REMOTE" ]; then
-      git pull "$REMOTE"
-    fi
-  fi
-fi
-
-if $UPDATE_MPY; then
-  MP_DIR="micropython"
-  if [ ! -d "$MP_DIR" ]; then
-    echo "Cloning Micropython repository..."
-    git clone --depth 1 https://github.com/micropython/micropython.git "$MP_DIR"
-  else
-    echo "Updating Micropython repository..."
-    (cd "$MP_DIR" && git pull)
-  fi
-fi
+$UPDATE_KERNEL && update_kernel
+$UPDATE_MPY && update_mpy
 


### PR DESCRIPTION
## Summary
- add interactive `update.sh` script to pull kernel or MicroPython sources individually or together
- document update utility in release notes

## Testing
- `tests/test_fs.sh`
- `tests/test_mem.sh`
- `tests/test_fatfs_compile.sh`
- `tests/test_ata_compile.sh`


------
https://chatgpt.com/codex/tasks/task_e_689084781e788330bd5e3150d0e2ffb1