### PR TITLE
Fix MicroPython module linking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ memory_test
 full_test_build.log
 full_test_boot.log
 full_test_cpu.log
+kernel/mpy_modules.c

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -19,6 +19,7 @@
 - Corrected ELF loader to handle 64-bit program headers, fixing invalid opcode crashes on boot
 - Kernel now links the I/O helper library so cpuid and rdtsc functions resolve
 - Fixed missing global declaration for `end` symbol causing build failures in `kernel_main`
+- Restored MicroPython module linking by embedding module sources and loading them during boot
 
 ## Improvements
 - Added priority-based ballooning allocator

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -15,6 +15,7 @@
 #include "runstate.h"
 #include "script.h"
 #include "micropython.h"
+#include "mpy_loader.h"
 #include "modexec.h"
 #include "syscall.h"
 #include "buildinfo.h"
@@ -189,6 +190,7 @@ void kernel_main(uint32_t magic, multiboot_info_t *mbi) {
        * MODULE_BASE_ADDR, but GRUB may load them at arbitrary addresses.
        * Copy each module to the expected location before jumping. */
     mp_runtime_init();
+    mpymod_load_all();
     multiboot_module_t *mods = (multiboot_module_t*)(uintptr_t)mbi->mods_addr;
     uint8_t *const load_addr = (uint8_t*)MODULE_BASE_ADDR;
     for (uint32_t i = 0; i < mbi->mods_count; i++) {
@@ -439,6 +441,7 @@ void kernel_main(uint32_t magic, multiboot_info_t *mbi) {
         current_user_app = 0;
     } else {
         mp_runtime_init();
+        mpymod_load_all();
         console_puts("run init as init\n");
         mp_runtime_exec((const char*)init_src, init_size);
         mp_runtime_deinit();


### PR DESCRIPTION
## Summary
- Generate embedded MicroPython module table and compile loader
- Load embedded modules at boot
- Ignore generated module table and update release notes

## Testing
- ⚠️ `./build.sh run nographic` *(QEMU installation required and did not complete in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68b0036e329883309e58d6df8b3d029f