### PR TITLE
Fix MicroPython module linking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ memory_test
 full_test_build.log
 full_test_boot.log
 full_test_cpu.log
+kernel/mpy_modules.c

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -19,6 +19,8 @@
 - Corrected ELF loader to handle 64-bit program headers, fixing invalid opcode crashes on boot
 - Kernel now links the I/O helper library so cpuid and rdtsc functions resolve
 - Fixed missing global declaration for `end` symbol causing build failures in `kernel_main`
+- Restored MicroPython module linking by embedding module sources and loading them during boot
+- Enabled `sys` and properly initialized built-in modules so embedded MicroPython scripts import without errors
 
 ## Improvements
 - Added priority-based ballooning allocator

--- a/build.sh
+++ b/build.sh
@@ -84,6 +84,17 @@ if [ ! -f "$MP_DIR/examples/embedding/mpconfigport.h" ]; then
   exit 1
 fi
 # Ensure persistent .mpy loading is enabled
+# Enable sys module for MicroPython runtime
+if grep -q "MICROPY_PY_SYS" "$MP_DIR/examples/embedding/mpconfigport.h"; then
+  sed -i 's/^#define MICROPY_PY_SYS.*/#define MICROPY_PY_SYS (1)/' "$MP_DIR/examples/embedding/mpconfigport.h"
+else
+  echo "#define MICROPY_PY_SYS (1)" >> "$MP_DIR/examples/embedding/mpconfigport.h"
+fi
+if grep -q "MICROPY_PY_SYS_PLATFORM" "$MP_DIR/examples/embedding/mpconfigport.h"; then
+  sed -i 's/^#define MICROPY_PY_SYS_PLATFORM.*/#define MICROPY_PY_SYS_PLATFORM "exocore"/' "$MP_DIR/examples/embedding/mpconfigport.h"
+else
+  echo "#define MICROPY_PY_SYS_PLATFORM \"exocore\"" >> "$MP_DIR/examples/embedding/mpconfigport.h"
+fi
 if ! grep -q "MICROPY_PERSISTENT_CODE_LOAD" "$MP_DIR/examples/embedding/mpconfigport.h"; then
   echo "#define MICROPY_PERSISTENT_CODE_LOAD (1)" >> "$MP_DIR/examples/embedding/mpconfigport.h"
 fi
@@ -143,6 +154,42 @@ for native_dir in mpymod/*/native; do
     fi
   done
 done
+
+# Generate table of MicroPython modules for embedding
+MPY_MOD_C="kernel/mpy_modules.c"
+python3 - "$MPY_MOD_C" <<'PY'
+import os, sys, json
+out_path = sys.argv[1]
+with open(out_path, 'w') as out:
+    out.write('#include "mpy_loader.h"\n#include <stddef.h>\n\n')
+    entries = []
+    for mod in sorted(os.listdir('mpymod')):
+        mod_dir = os.path.join('mpymod', mod)
+        if not os.path.isdir(mod_dir):
+            continue
+        manifest = os.path.join(mod_dir, 'manifest.json')
+        name = mod
+        entry = 'init.py'
+        if os.path.exists(manifest):
+            data = json.load(open(manifest))
+            name = data.get('mpy_import_as', name)
+            entry = data.get('mpy_entry') or 'init.py'
+        src_path = os.path.join(mod_dir, entry)
+        if not os.path.exists(src_path):
+            continue
+        with open(src_path, 'rb') as f:
+            data = f.read()
+        var = mod.replace('-', '_')
+        out.write(f'static const unsigned char {var}_src[] = {{')
+        out.write(','.join(f'0x{b:02x}' for b in data))
+        out.write('};\n')
+        entries.append((name, var, len(data)))
+    out.write('const mpymod_entry_t mpymod_table[] = {\n')
+    for name, var, length in entries:
+        out.write(f'    {{"{name}", (const char*){var}_src, {length}}},\n')
+    out.write('};\n')
+    out.write(f'const size_t mpymod_table_count = {len(entries)};\n')
+PY
 
 # rebuild embed port to include patched mphalport.c and any user modules
 rm -rf "$MP_DIR/examples/embedding/build-embed"
@@ -236,6 +283,7 @@ fi
 rm -f arch/x86/boot.o arch/x86/idt.o \
       kernel/main.o kernel/mem.o kernel/console.o \
       kernel/idt.o kernel/panic.o kernel/debuglog.o kernel/io.o \
+      kernel/micropython.o kernel/mpy_loader.o kernel/mpy_modules.o \
       kernel.bin exocore.iso
 rm -rf isodir run/*.o run/*.elf run/*.bin run/*.mpy run/linkdep_objs run/linkdep.a
 
@@ -418,6 +466,10 @@ $CC $ARCH_FLAG -std=gnu99 -ffreestanding -O2 $STACK_FLAGS -fcf-protection=none -
 $CC $ARCH_FLAG -std=gnu99 -ffreestanding -O2 $STACK_FLAGS -fcf-protection=none -Wall -U__linux__ -Iinclude \
     -c kernel/modexec.c -o kernel/modexec.o
 $CC $ARCH_FLAG -std=gnu99 -ffreestanding -O2 $STACK_FLAGS -fcf-protection=none -Wall -U__linux__ -Iinclude \
+    -c kernel/mpy_loader.c -o kernel/mpy_loader.o
+$CC $ARCH_FLAG -std=gnu99 -ffreestanding -O2 $STACK_FLAGS -fcf-protection=none -Wall -U__linux__ -Iinclude \
+    -c kernel/mpy_modules.c -o kernel/mpy_modules.o
+$CC $ARCH_FLAG -std=gnu99 -ffreestanding -O2 $STACK_FLAGS -fcf-protection=none -Wall -U__linux__ -Iinclude \
     -c linkdep/io.c -o kernel/io.o
 # 9) Link into flat kernel.bin
 echo "Linking kernel.bin..."
@@ -425,7 +477,7 @@ $LD -m $LDARCH -T linker.ld \
     arch/x86/boot.o arch/x86/idt.o arch/x86/user.o \
     kernel/main.o kernel/mem.o kernel/console.o kernel/serial.o \
     kernel/idt.o kernel/panic.o kernel/memutils.o kernel/fs.o kernel/script.o \
-    kernel/debuglog.o kernel/syscall.o kernel/micropython.o kernel/modexec.o ${MP_OBJS[@]} kernel/io.o \
+    kernel/debuglog.o kernel/syscall.o kernel/micropython.o kernel/mpy_loader.o kernel/mpy_modules.o kernel/modexec.o ${MP_OBJS[@]} kernel/io.o \
     -o kernel.bin
 
 # 10) Prepare ISO tree

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -15,6 +15,7 @@
 #include "runstate.h"
 #include "script.h"
 #include "micropython.h"
+#include "mpy_loader.h"
 #include "modexec.h"
 #include "syscall.h"
 #include "buildinfo.h"
@@ -189,6 +190,7 @@ void kernel_main(uint32_t magic, multiboot_info_t *mbi) {
        * MODULE_BASE_ADDR, but GRUB may load them at arbitrary addresses.
        * Copy each module to the expected location before jumping. */
     mp_runtime_init();
+    mpymod_load_all();
     multiboot_module_t *mods = (multiboot_module_t*)(uintptr_t)mbi->mods_addr;
     uint8_t *const load_addr = (uint8_t*)MODULE_BASE_ADDR;
     for (uint32_t i = 0; i < mbi->mods_count; i++) {
@@ -439,6 +441,7 @@ void kernel_main(uint32_t magic, multiboot_info_t *mbi) {
         current_user_app = 0;
     } else {
         mp_runtime_init();
+        mpymod_load_all();
         console_puts("run init as init\n");
         mp_runtime_exec((const char*)init_src, init_size);
         mp_runtime_deinit();

--- a/kernel/micropython.c
+++ b/kernel/micropython.c
@@ -7,6 +7,7 @@
 #include "py/stackctrl.h"
 #include "py/objmodule.h"
 #include "py/runtime.h"
+#include "py/qstr.h"
 
 #ifndef STATIC
 #define STATIC static
@@ -30,24 +31,17 @@ void mp_runtime_init(void) {
         mp_embed_init(mp_heap, sizeof(mp_heap), &stack_dummy);
         mp_stack_set_limit(16 * 1024);
         /* create real 'env' module for MicroPython */
-        mp_obj_dict_t *env_globals = mp_obj_new_dict(0);
-        mp_obj_module_t *env_mod = m_new_obj(mp_obj_module_t);
-        env_mod->base.type = &mp_type_module;
-        env_mod->globals = env_globals;
-        mp_obj_dict_store(MP_OBJ_FROM_PTR(&MP_STATE_VM(mp_loaded_modules_dict)),
-            mp_obj_new_str("env", 3), MP_OBJ_FROM_PTR(env_mod));
-
-        /* shared environment dictionary */
+        qstr env_qstr = qstr_from_str("env");
+        mp_obj_t env_mod = mp_obj_new_module(env_qstr);
+        mp_obj_dict_t *env_globals = mp_obj_module_get_globals(env_mod);
         mp_obj_t env_dict = mp_obj_new_dict(0);
-        mp_obj_dict_store(env_globals, mp_obj_new_str("env", 3), env_dict);
+        mp_obj_dict_store(MP_OBJ_FROM_PTR(env_globals), MP_OBJ_NEW_QSTR(env_qstr), env_dict);
 
         /* create built-in 'c' module with execo() */
-        mp_obj_dict_t *c_globals = mp_obj_new_dict(0);
-        mp_obj_dict_store(c_globals, mp_obj_new_str("execo", 6), MP_OBJ_FROM_PTR(&mp_c_execo_obj));
-        mp_obj_module_t *c_mod = m_new_obj(mp_obj_module_t);
-        c_mod->base.type = &mp_type_module;
-        c_mod->globals = c_globals;
-        mp_obj_dict_store(MP_OBJ_FROM_PTR(&MP_STATE_VM(mp_loaded_modules_dict)), mp_obj_new_str("c", 1), MP_OBJ_FROM_PTR(c_mod));
+        qstr c_qstr = qstr_from_str("c");
+        mp_obj_t c_mod = mp_obj_new_module(c_qstr);
+        mp_obj_dict_t *c_globals = mp_obj_module_get_globals(c_mod);
+        mp_obj_dict_store(MP_OBJ_FROM_PTR(c_globals), MP_OBJ_NEW_QSTR(qstr_from_str("execo")), MP_OBJ_FROM_PTR(&mp_c_execo_obj));
 
         /* expose helper functions via Python stub */
         mp_embed_exec_str(


### PR DESCRIPTION
## Summary
- Enable `sys` support in the embedded MicroPython build and set a platform name
- Initialize `env` and `c` modules through the MicroPython API so runtime imports succeed
- Note MicroPython runtime initialization fix in release notes

## Testing
- `./build.sh run nographic`


------
https://chatgpt.com/codex/tasks/task_e_68b0036e329883309e58d6df8b3d029f