### PR TITLE
Add kernel-integrated MicroPython utility modules

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,7 @@
 ## New Features
 - Ring-3 syscall interface for init.elf covering memory, filesystem and process control
 - init.elf executes in user mode with kernel memory protection
+- Added ten kernel-integrated MicroPython libraries providing console, serial, debug logging, memory, filesystem, run-state, hardware, keyboard, TinyScript, and module execution helpers
 
 ## Improvements
 - IDT adds user-accessible system call gate ensuring ring-3 access

--- a/include/fs.h
+++ b/include/fs.h
@@ -17,6 +17,12 @@ size_t fs_read(size_t offset, void *buf, size_t len);
 /* Write up to 'len' bytes to 'offset'. Returns bytes written. */
 size_t fs_write(size_t offset, const void *data, size_t len);
 
+/* Total capacity of the backing store in bytes (0 if unmounted). */
+size_t fs_capacity(void);
+
+/* Non-zero if a backing store is currently mounted. */
+int fs_is_mounted(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/kernel/fs.c
+++ b/kernel/fs.c
@@ -45,3 +45,11 @@ size_t fs_write(size_t offset, const void *data, size_t len) {
     debuglog_hexdump(data, len > 64 ? 64 : len);
     return len;
 }
+
+int fs_is_mounted(void) {
+    return fs_data != NULL;
+}
+
+size_t fs_capacity(void) {
+    return fs_size;
+}

--- a/mpymod/consolectl/init.py
+++ b/mpymod/consolectl/init.py
@@ -1,0 +1,34 @@
+print("consolectl module loaded")
+from env import env
+import consolectl_native as _native
+
+COLORS = _native.colors()
+
+def write(text):
+    text = str(text)
+    return _native.write(text)
+
+def clear():
+    _native.clear()
+
+
+def set_attr(fg, bg):
+    _native.set_attr(int(fg), int(bg))
+
+
+def scroll(lines=1):
+    _native.scroll(int(lines))
+
+
+def backspace(count=1):
+    _native.backspace(int(count))
+
+
+env['console'] = {
+    'write': write,
+    'clear': clear,
+    'set_attr': set_attr,
+    'scroll': scroll,
+    'backspace': backspace,
+    'colors': COLORS,
+}

--- a/mpymod/consolectl/manifest.json
+++ b/mpymod/consolectl/manifest.json
@@ -1,0 +1,4 @@
+{
+  "mpy_entry": "init.py",
+  "mpy_import_as": "consolectl"
+}

--- a/mpymod/consolectl/native/consolectl.c
+++ b/mpymod/consolectl/native/consolectl.c
@@ -1,0 +1,103 @@
+#include "py/runtime.h"
+#include "console.h"
+#include <string.h>
+
+STATIC mp_obj_t consolectl_write(mp_obj_t text_obj) {
+    mp_uint_t len;
+    const char *data = mp_obj_str_get_data(text_obj, &len);
+    for (mp_uint_t i = 0; i < len; ++i) {
+        console_putc(data[i]);
+    }
+    return mp_obj_new_int(len);
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(consolectl_write_obj, consolectl_write);
+
+STATIC mp_obj_t consolectl_clear(void) {
+    console_clear();
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_0(consolectl_clear_obj, consolectl_clear);
+
+STATIC mp_obj_t consolectl_set_attr(mp_obj_t fg_obj, mp_obj_t bg_obj) {
+    uint8_t fg = (uint8_t)mp_obj_get_int(fg_obj);
+    uint8_t bg = (uint8_t)mp_obj_get_int(bg_obj);
+    console_set_attr(fg, bg);
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_2(consolectl_set_attr_obj, consolectl_set_attr);
+
+STATIC mp_obj_t consolectl_scroll(mp_obj_t lines_obj) {
+    int lines = mp_obj_get_int(lines_obj);
+    if (lines > 0) {
+        for (int i = 0; i < lines; ++i) {
+            console_scroll_down();
+        }
+    } else if (lines < 0) {
+        for (int i = 0; i < -lines; ++i) {
+            console_scroll_up();
+        }
+    }
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(consolectl_scroll_obj, consolectl_scroll);
+
+STATIC mp_obj_t consolectl_backspace(mp_obj_t count_obj) {
+    int count = mp_obj_get_int(count_obj);
+    if (count < 0) {
+        count = 0;
+    }
+    for (int i = 0; i < count; ++i) {
+        console_backspace();
+    }
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(consolectl_backspace_obj, consolectl_backspace);
+
+STATIC mp_obj_t consolectl_colors(void) {
+    STATIC const struct {
+        const char *name;
+        uint8_t value;
+    } table[] = {
+        {"black", VGA_BLACK},
+        {"blue", VGA_BLUE},
+        {"green", VGA_GREEN},
+        {"cyan", VGA_CYAN},
+        {"red", VGA_RED},
+        {"magenta", VGA_MAGENTA},
+        {"brown", VGA_BROWN},
+        {"light_grey", VGA_LIGHT_GREY},
+        {"dark_grey", VGA_DARK_GREY},
+        {"light_blue", VGA_LIGHT_BLUE},
+        {"light_green", VGA_LIGHT_GREEN},
+        {"light_cyan", VGA_LIGHT_CYAN},
+        {"light_red", VGA_LIGHT_RED},
+        {"light_magenta", VGA_LIGHT_MAGENTA},
+        {"yellow", VGA_YELLOW},
+        {"white", VGA_WHITE},
+    };
+    mp_obj_t dict = mp_obj_new_dict(0);
+    for (size_t i = 0; i < MP_ARRAY_SIZE(table); ++i) {
+        mp_obj_dict_store(dict,
+            mp_obj_new_str(table[i].name, strlen(table[i].name)),
+            mp_obj_new_int(table[i].value));
+    }
+    return dict;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_0(consolectl_colors_obj, consolectl_colors);
+
+STATIC const mp_rom_map_elem_t consolectl_module_globals_table[] = {
+    { MP_ROM_QSTR(MP_QSTR_write), MP_ROM_PTR(&consolectl_write_obj) },
+    { MP_ROM_QSTR(MP_QSTR_clear), MP_ROM_PTR(&consolectl_clear_obj) },
+    { MP_ROM_QSTR(MP_QSTR_set_attr), MP_ROM_PTR(&consolectl_set_attr_obj) },
+    { MP_ROM_QSTR(MP_QSTR_scroll), MP_ROM_PTR(&consolectl_scroll_obj) },
+    { MP_ROM_QSTR(MP_QSTR_backspace), MP_ROM_PTR(&consolectl_backspace_obj) },
+    { MP_ROM_QSTR(MP_QSTR_colors), MP_ROM_PTR(&consolectl_colors_obj) },
+};
+STATIC MP_DEFINE_CONST_DICT(consolectl_module_globals, consolectl_module_globals_table);
+
+const mp_obj_module_t consolectl_native_user_cmodule = {
+    .base = { &mp_type_module },
+    .globals = (mp_obj_dict_t*)&consolectl_module_globals,
+};
+
+MP_REGISTER_MODULE(MP_QSTR_consolectl_native, consolectl_native_user_cmodule);

--- a/mpymod/debugview/init.py
+++ b/mpymod/debugview/init.py
@@ -1,0 +1,17 @@
+print("debugview module loaded")
+from env import env
+import debugview_native as _native
+
+flush = _native.flush
+dump_console = _native.dump_console
+save_file = _native.save_file
+buffer = _native.buffer
+is_available = _native.is_available
+
+env['debuglog'] = {
+    'flush': flush,
+    'dump_console': dump_console,
+    'save_file': save_file,
+    'buffer': buffer,
+    'is_available': is_available,
+}

--- a/mpymod/debugview/manifest.json
+++ b/mpymod/debugview/manifest.json
@@ -1,0 +1,4 @@
+{
+  "mpy_entry": "init.py",
+  "mpy_import_as": "debugview"
+}

--- a/mpymod/debugview/native/debugview.c
+++ b/mpymod/debugview/native/debugview.c
@@ -1,0 +1,51 @@
+#include "py/runtime.h"
+#include "debuglog.h"
+
+STATIC mp_obj_t debugview_flush(void) {
+    debuglog_flush();
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_0(debugview_flush_obj, debugview_flush);
+
+STATIC mp_obj_t debugview_dump_console(void) {
+    debuglog_dump_console();
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_0(debugview_dump_console_obj, debugview_dump_console);
+
+STATIC mp_obj_t debugview_save_file(void) {
+    debuglog_save_file();
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_0(debugview_save_file_obj, debugview_save_file);
+
+STATIC mp_obj_t debugview_buffer(void) {
+    const char *buf = debuglog_buffer();
+    size_t len = debuglog_length();
+    if (!buf || len == 0) {
+        return mp_const_empty_bytes;
+    }
+    return mp_obj_new_bytes((const unsigned char *)buf, len);
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_0(debugview_buffer_obj, debugview_buffer);
+
+STATIC mp_obj_t debugview_is_available(void) {
+    return mp_obj_new_bool(debuglog_buffer() != NULL);
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_0(debugview_is_available_obj, debugview_is_available);
+
+STATIC const mp_rom_map_elem_t debugview_module_globals_table[] = {
+    { MP_ROM_QSTR(MP_QSTR_flush), MP_ROM_PTR(&debugview_flush_obj) },
+    { MP_ROM_QSTR(MP_QSTR_dump_console), MP_ROM_PTR(&debugview_dump_console_obj) },
+    { MP_ROM_QSTR(MP_QSTR_save_file), MP_ROM_PTR(&debugview_save_file_obj) },
+    { MP_ROM_QSTR(MP_QSTR_buffer), MP_ROM_PTR(&debugview_buffer_obj) },
+    { MP_ROM_QSTR(MP_QSTR_is_available), MP_ROM_PTR(&debugview_is_available_obj) },
+};
+STATIC MP_DEFINE_CONST_DICT(debugview_module_globals, debugview_module_globals_table);
+
+const mp_obj_module_t debugview_native_user_cmodule = {
+    .base = { &mp_type_module },
+    .globals = (mp_obj_dict_t*)&debugview_module_globals,
+};
+
+MP_REGISTER_MODULE(MP_QSTR_debugview_native, debugview_native_user_cmodule);

--- a/mpymod/fsbridge/init.py
+++ b/mpymod/fsbridge/init.py
@@ -1,0 +1,15 @@
+print("fsbridge module loaded")
+from env import env
+import fsbridge_native as _native
+
+read = _native.read
+write = _native.write
+capacity = _native.capacity
+is_mounted = _native.is_mounted
+
+env['fs'] = {
+    'read': read,
+    'write': write,
+    'capacity': capacity,
+    'is_mounted': is_mounted,
+}

--- a/mpymod/fsbridge/manifest.json
+++ b/mpymod/fsbridge/manifest.json
@@ -1,0 +1,4 @@
+{
+  "mpy_entry": "init.py",
+  "mpy_import_as": "fsbridge"
+}

--- a/mpymod/fsbridge/native/fsbridge.c
+++ b/mpymod/fsbridge/native/fsbridge.c
@@ -1,0 +1,56 @@
+#include "py/runtime.h"
+#include "py/objstr.h"
+#include "fs.h"
+#include <string.h>
+
+STATIC mp_obj_t fsbridge_read(mp_obj_t offset_obj, mp_obj_t length_obj) {
+    size_t offset = (size_t)mp_obj_get_int(offset_obj);
+    size_t length = (size_t)mp_obj_get_int(length_obj);
+    if (length == 0) {
+        return mp_const_empty_bytes;
+    }
+    vstr_t vstr;
+    vstr_init_len(&vstr, length);
+    size_t read = fs_read(offset, vstr.buf, length);
+    if (read < length) {
+        vstr.len = read;
+    }
+    mp_obj_t result = mp_obj_new_bytes((const unsigned char *)vstr.buf, vstr.len);
+    vstr_clear(&vstr);
+    return result;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_2(fsbridge_read_obj, fsbridge_read);
+
+STATIC mp_obj_t fsbridge_write(mp_obj_t offset_obj, mp_obj_t data_obj) {
+    size_t offset = (size_t)mp_obj_get_int(offset_obj);
+    mp_uint_t len;
+    const char *data = mp_obj_str_get_data(data_obj, &len);
+    size_t written = fs_write(offset, data, len);
+    return mp_obj_new_int_from_uint((mp_uint_t)written);
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_2(fsbridge_write_obj, fsbridge_write);
+
+STATIC mp_obj_t fsbridge_capacity(void) {
+    return mp_obj_new_int_from_ull((unsigned long long)fs_capacity());
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_0(fsbridge_capacity_obj, fsbridge_capacity);
+
+STATIC mp_obj_t fsbridge_is_mounted(void) {
+    return mp_obj_new_bool(fs_is_mounted());
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_0(fsbridge_is_mounted_obj, fsbridge_is_mounted);
+
+STATIC const mp_rom_map_elem_t fsbridge_module_globals_table[] = {
+    { MP_ROM_QSTR(MP_QSTR_read), MP_ROM_PTR(&fsbridge_read_obj) },
+    { MP_ROM_QSTR(MP_QSTR_write), MP_ROM_PTR(&fsbridge_write_obj) },
+    { MP_ROM_QSTR(MP_QSTR_capacity), MP_ROM_PTR(&fsbridge_capacity_obj) },
+    { MP_ROM_QSTR(MP_QSTR_is_mounted), MP_ROM_PTR(&fsbridge_is_mounted_obj) },
+};
+STATIC MP_DEFINE_CONST_DICT(fsbridge_module_globals, fsbridge_module_globals_table);
+
+const mp_obj_module_t fsbridge_native_user_cmodule = {
+    .base = { &mp_type_module },
+    .globals = (mp_obj_dict_t*)&fsbridge_module_globals,
+};
+
+MP_REGISTER_MODULE(MP_QSTR_fsbridge_native, fsbridge_native_user_cmodule);

--- a/mpymod/hwinfo/init.py
+++ b/mpymod/hwinfo/init.py
@@ -1,0 +1,15 @@
+print("hwinfo module loaded")
+from env import env
+import hwinfo_native as _native
+
+rdtsc = _native.rdtsc
+cpuid = _native.cpuid
+inb = _native.inb
+outb = _native.outb
+
+env['hwinfo'] = {
+    'rdtsc': rdtsc,
+    'cpuid': cpuid,
+    'inb': inb,
+    'outb': outb,
+}

--- a/mpymod/hwinfo/manifest.json
+++ b/mpymod/hwinfo/manifest.json
@@ -1,0 +1,4 @@
+{
+  "mpy_entry": "init.py",
+  "mpy_import_as": "hwinfo"
+}

--- a/mpymod/hwinfo/native/hwinfo.c
+++ b/mpymod/hwinfo/native/hwinfo.c
@@ -1,0 +1,51 @@
+#include "py/runtime.h"
+#include "io.h"
+
+STATIC mp_obj_t hwinfo_rdtsc(void) {
+    return mp_obj_new_int_from_ull(io_rdtsc());
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_0(hwinfo_rdtsc_obj, hwinfo_rdtsc);
+
+STATIC mp_obj_t hwinfo_cpuid(mp_obj_t leaf_obj) {
+    uint32_t leaf = (uint32_t)mp_obj_get_int(leaf_obj);
+    uint32_t a, b, c, d;
+    io_cpuid(leaf, &a, &b, &c, &d);
+    mp_obj_t tuple[4] = {
+        mp_obj_new_int_from_uint(a),
+        mp_obj_new_int_from_uint(b),
+        mp_obj_new_int_from_uint(c),
+        mp_obj_new_int_from_uint(d),
+    };
+    return mp_obj_new_tuple(4, tuple);
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(hwinfo_cpuid_obj, hwinfo_cpuid);
+
+STATIC mp_obj_t hwinfo_inb(mp_obj_t port_obj) {
+    uint16_t port = (uint16_t)mp_obj_get_int(port_obj);
+    uint8_t value = io_inb(port);
+    return mp_obj_new_int_from_uint(value);
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(hwinfo_inb_obj, hwinfo_inb);
+
+STATIC mp_obj_t hwinfo_outb(mp_obj_t port_obj, mp_obj_t value_obj) {
+    uint16_t port = (uint16_t)mp_obj_get_int(port_obj);
+    uint8_t value = (uint8_t)mp_obj_get_int(value_obj);
+    io_outb(port, value);
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_2(hwinfo_outb_obj, hwinfo_outb);
+
+STATIC const mp_rom_map_elem_t hwinfo_module_globals_table[] = {
+    { MP_ROM_QSTR(MP_QSTR_rdtsc), MP_ROM_PTR(&hwinfo_rdtsc_obj) },
+    { MP_ROM_QSTR(MP_QSTR_cpuid), MP_ROM_PTR(&hwinfo_cpuid_obj) },
+    { MP_ROM_QSTR(MP_QSTR_inb), MP_ROM_PTR(&hwinfo_inb_obj) },
+    { MP_ROM_QSTR(MP_QSTR_outb), MP_ROM_PTR(&hwinfo_outb_obj) },
+};
+STATIC MP_DEFINE_CONST_DICT(hwinfo_module_globals, hwinfo_module_globals_table);
+
+const mp_obj_module_t hwinfo_native_user_cmodule = {
+    .base = { &mp_type_module },
+    .globals = (mp_obj_dict_t*)&hwinfo_module_globals,
+};
+
+MP_REGISTER_MODULE(MP_QSTR_hwinfo_native, hwinfo_native_user_cmodule);

--- a/mpymod/keyinput/init.py
+++ b/mpymod/keyinput/init.py
@@ -1,0 +1,11 @@
+print("keyinput module loaded")
+from env import env
+import keyinput_native as _native
+
+read_char = _native.read_char
+read_code = _native.read_code
+
+env['keyboard'] = {
+    'read_char': read_char,
+    'read_code': read_code,
+}

--- a/mpymod/keyinput/manifest.json
+++ b/mpymod/keyinput/manifest.json
@@ -1,0 +1,4 @@
+{
+  "mpy_entry": "init.py",
+  "mpy_import_as": "keyinput"
+}

--- a/mpymod/keyinput/native/keyinput.c
+++ b/mpymod/keyinput/native/keyinput.c
@@ -1,0 +1,35 @@
+#include "py/runtime.h"
+#include "console.h"
+
+STATIC mp_obj_t keyinput_read_code(void) {
+    int value = (unsigned char)console_getc();
+    return mp_obj_new_int(value);
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_0(keyinput_read_code_obj, keyinput_read_code);
+
+STATIC mp_obj_t keyinput_read_char(void) {
+    int value = (unsigned char)console_getc();
+    if (value >= 32 || value == '\n' || value == '\r' || value == '\t') {
+        char ch = (char)value;
+        return mp_obj_new_str(&ch, 1);
+    }
+    if (value == '\b') {
+        char ch = '\b';
+        return mp_obj_new_str(&ch, 1);
+    }
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_0(keyinput_read_char_obj, keyinput_read_char);
+
+STATIC const mp_rom_map_elem_t keyinput_module_globals_table[] = {
+    { MP_ROM_QSTR(MP_QSTR_read_char), MP_ROM_PTR(&keyinput_read_char_obj) },
+    { MP_ROM_QSTR(MP_QSTR_read_code), MP_ROM_PTR(&keyinput_read_code_obj) },
+};
+STATIC MP_DEFINE_CONST_DICT(keyinput_module_globals, keyinput_module_globals_table);
+
+const mp_obj_module_t keyinput_native_user_cmodule = {
+    .base = { &mp_type_module },
+    .globals = (mp_obj_dict_t*)&keyinput_module_globals,
+};
+
+MP_REGISTER_MODULE(MP_QSTR_keyinput_native, keyinput_native_user_cmodule);

--- a/mpymod/memstats/init.py
+++ b/mpymod/memstats/init.py
@@ -1,0 +1,17 @@
+print("memstats module loaded")
+from env import env
+import memstats_native as _native
+
+heap_free = _native.heap_free
+register_app = _native.register_app
+app_used = _native.app_used
+save_block = _native.save_block
+load_block = _native.load_block
+
+env['memory'] = {
+    'heap_free': heap_free,
+    'register_app': register_app,
+    'app_used': app_used,
+    'save_block': save_block,
+    'load_block': load_block,
+}

--- a/mpymod/memstats/manifest.json
+++ b/mpymod/memstats/manifest.json
@@ -1,0 +1,4 @@
+{
+  "mpy_entry": "init.py",
+  "mpy_import_as": "memstats"
+}

--- a/mpymod/memstats/native/memstats.c
+++ b/mpymod/memstats/native/memstats.c
@@ -1,0 +1,58 @@
+#include "py/runtime.h"
+#include "mem.h"
+
+STATIC mp_obj_t memstats_heap_free(void) {
+    return mp_obj_new_int_from_ull((unsigned long long)mem_heap_free());
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_0(memstats_heap_free_obj, memstats_heap_free);
+
+STATIC mp_obj_t memstats_register_app(mp_obj_t priority_obj) {
+    int priority = mp_obj_get_int(priority_obj);
+    int id = mem_register_app((uint8_t)priority);
+    return mp_obj_new_int(id);
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(memstats_register_app_obj, memstats_register_app);
+
+STATIC mp_obj_t memstats_app_used(mp_obj_t app_id_obj) {
+    int app_id = mp_obj_get_int(app_id_obj);
+    size_t used = mem_app_used(app_id);
+    return mp_obj_new_int_from_ull((unsigned long long)used);
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(memstats_app_used_obj, memstats_app_used);
+
+STATIC mp_obj_t memstats_save_block(mp_obj_t app_id_obj, mp_obj_t data_obj) {
+    int app_id = mp_obj_get_int(app_id_obj);
+    mp_uint_t len;
+    const char *data = mp_obj_str_get_data(data_obj, &len);
+    int handle = mem_save_app(app_id, data, len);
+    return mp_obj_new_int(handle);
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_2(memstats_save_block_obj, memstats_save_block);
+
+STATIC mp_obj_t memstats_load_block(mp_obj_t app_id_obj, mp_obj_t handle_obj) {
+    int app_id = mp_obj_get_int(app_id_obj);
+    int handle = mp_obj_get_int(handle_obj);
+    size_t size = 0;
+    void *ptr = mem_retrieve_app(app_id, handle, &size);
+    if (!ptr || size == 0) {
+        return mp_const_none;
+    }
+    return mp_obj_new_bytes((const unsigned char *)ptr, size);
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_2(memstats_load_block_obj, memstats_load_block);
+
+STATIC const mp_rom_map_elem_t memstats_module_globals_table[] = {
+    { MP_ROM_QSTR(MP_QSTR_heap_free), MP_ROM_PTR(&memstats_heap_free_obj) },
+    { MP_ROM_QSTR(MP_QSTR_register_app), MP_ROM_PTR(&memstats_register_app_obj) },
+    { MP_ROM_QSTR(MP_QSTR_app_used), MP_ROM_PTR(&memstats_app_used_obj) },
+    { MP_ROM_QSTR(MP_QSTR_save_block), MP_ROM_PTR(&memstats_save_block_obj) },
+    { MP_ROM_QSTR(MP_QSTR_load_block), MP_ROM_PTR(&memstats_load_block_obj) },
+};
+STATIC MP_DEFINE_CONST_DICT(memstats_module_globals, memstats_module_globals_table);
+
+const mp_obj_module_t memstats_native_user_cmodule = {
+    .base = { &mp_type_module },
+    .globals = (mp_obj_dict_t*)&memstats_module_globals,
+};
+
+MP_REGISTER_MODULE(MP_QSTR_memstats_native, memstats_native_user_cmodule);

--- a/mpymod/modrunner/init.py
+++ b/mpymod/modrunner/init.py
@@ -1,0 +1,20 @@
+print("modrunner module loaded")
+from env import env
+import modrunner_native as _native
+
+run = _native.run
+
+
+def run_many(names):
+    if not isinstance(names, (list, tuple)):
+        raise TypeError('expected list or tuple of module names')
+    results = []
+    for name in names:
+        result = _native.run(str(name))
+        results.append(result)
+    return results
+
+env['modules'] = {
+    'run': run,
+    'run_many': run_many,
+}

--- a/mpymod/modrunner/manifest.json
+++ b/mpymod/modrunner/manifest.json
@@ -1,0 +1,4 @@
+{
+  "mpy_entry": "init.py",
+  "mpy_import_as": "modrunner"
+}

--- a/mpymod/modrunner/native/modrunner.c
+++ b/mpymod/modrunner/native/modrunner.c
@@ -1,0 +1,22 @@
+#include "py/runtime.h"
+#include "modexec.h"
+
+STATIC mp_obj_t modrunner_run(mp_obj_t name_obj) {
+    mp_uint_t len;
+    const char *name = mp_obj_str_get_data(name_obj, &len);
+    int rc = modexec_run(name);
+    return mp_obj_new_int(rc);
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(modrunner_run_obj, modrunner_run);
+
+STATIC const mp_rom_map_elem_t modrunner_module_globals_table[] = {
+    { MP_ROM_QSTR(MP_QSTR_run), MP_ROM_PTR(&modrunner_run_obj) },
+};
+STATIC MP_DEFINE_CONST_DICT(modrunner_module_globals, modrunner_module_globals_table);
+
+const mp_obj_module_t modrunner_native_user_cmodule = {
+    .base = { &mp_type_module },
+    .globals = (mp_obj_dict_t*)&modrunner_module_globals,
+};
+
+MP_REGISTER_MODULE(MP_QSTR_modrunner_native, modrunner_native_user_cmodule);

--- a/mpymod/runstatectl/init.py
+++ b/mpymod/runstatectl/init.py
@@ -1,0 +1,23 @@
+print("runstatectl module loaded")
+from env import env
+import runstatectl_native as _native
+
+current_program = _native.current_program
+set_current_program = _native.set_current_program
+current_user_app = _native.current_user_app
+set_current_user_app = _native.set_current_user_app
+is_debug_mode = _native.is_debug_mode
+set_debug_mode = _native.set_debug_mode
+is_vga_output = _native.is_vga_output
+set_vga_output = _native.set_vga_output
+
+env['runstate'] = {
+    'current_program': current_program,
+    'set_current_program': set_current_program,
+    'current_user_app': current_user_app,
+    'set_current_user_app': set_current_user_app,
+    'is_debug_mode': is_debug_mode,
+    'set_debug_mode': set_debug_mode,
+    'is_vga_output': is_vga_output,
+    'set_vga_output': set_vga_output,
+}

--- a/mpymod/runstatectl/manifest.json
+++ b/mpymod/runstatectl/manifest.json
@@ -1,0 +1,4 @@
+{
+  "mpy_entry": "init.py",
+  "mpy_import_as": "runstatectl"
+}

--- a/mpymod/runstatectl/native/runstatectl.c
+++ b/mpymod/runstatectl/native/runstatectl.c
@@ -1,0 +1,76 @@
+#include "py/runtime.h"
+#include "runstate.h"
+#include <string.h>
+
+STATIC char current_program_buf[64];
+
+STATIC mp_obj_t runstatectl_current_program(void) {
+    const char *name = current_program ? current_program : "";
+    return mp_obj_new_str(name, strlen(name));
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_0(runstatectl_current_program_obj, runstatectl_current_program);
+
+STATIC mp_obj_t runstatectl_set_current_program(mp_obj_t name_obj) {
+    mp_uint_t len;
+    const char *src = mp_obj_str_get_data(name_obj, &len);
+    if (len >= sizeof(current_program_buf)) {
+        len = sizeof(current_program_buf) - 1;
+    }
+    memcpy(current_program_buf, src, len);
+    current_program_buf[len] = '\0';
+    current_program = current_program_buf;
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(runstatectl_set_current_program_obj, runstatectl_set_current_program);
+
+STATIC mp_obj_t runstatectl_current_user_app(void) {
+    return mp_obj_new_int(current_user_app);
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_0(runstatectl_current_user_app_obj, runstatectl_current_user_app);
+
+STATIC mp_obj_t runstatectl_set_current_user_app(mp_obj_t value_obj) {
+    current_user_app = mp_obj_get_int(value_obj);
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(runstatectl_set_current_user_app_obj, runstatectl_set_current_user_app);
+
+STATIC mp_obj_t runstatectl_is_debug_mode(void) {
+    return mp_obj_new_bool(debug_mode != 0);
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_0(runstatectl_is_debug_mode_obj, runstatectl_is_debug_mode);
+
+STATIC mp_obj_t runstatectl_set_debug_mode(mp_obj_t flag_obj) {
+    debug_mode = mp_obj_is_true(flag_obj);
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(runstatectl_set_debug_mode_obj, runstatectl_set_debug_mode);
+
+STATIC mp_obj_t runstatectl_is_vga_output(void) {
+    return mp_obj_new_bool(mp_vga_output != 0);
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_0(runstatectl_is_vga_output_obj, runstatectl_is_vga_output);
+
+STATIC mp_obj_t runstatectl_set_vga_output(mp_obj_t flag_obj) {
+    mp_vga_output = mp_obj_is_true(flag_obj);
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(runstatectl_set_vga_output_obj, runstatectl_set_vga_output);
+
+STATIC const mp_rom_map_elem_t runstatectl_module_globals_table[] = {
+    { MP_ROM_QSTR(MP_QSTR_current_program), MP_ROM_PTR(&runstatectl_current_program_obj) },
+    { MP_ROM_QSTR(MP_QSTR_set_current_program), MP_ROM_PTR(&runstatectl_set_current_program_obj) },
+    { MP_ROM_QSTR(MP_QSTR_current_user_app), MP_ROM_PTR(&runstatectl_current_user_app_obj) },
+    { MP_ROM_QSTR(MP_QSTR_set_current_user_app), MP_ROM_PTR(&runstatectl_set_current_user_app_obj) },
+    { MP_ROM_QSTR(MP_QSTR_is_debug_mode), MP_ROM_PTR(&runstatectl_is_debug_mode_obj) },
+    { MP_ROM_QSTR(MP_QSTR_set_debug_mode), MP_ROM_PTR(&runstatectl_set_debug_mode_obj) },
+    { MP_ROM_QSTR(MP_QSTR_is_vga_output), MP_ROM_PTR(&runstatectl_is_vga_output_obj) },
+    { MP_ROM_QSTR(MP_QSTR_set_vga_output), MP_ROM_PTR(&runstatectl_set_vga_output_obj) },
+};
+STATIC MP_DEFINE_CONST_DICT(runstatectl_module_globals, runstatectl_module_globals_table);
+
+const mp_obj_module_t runstatectl_native_user_cmodule = {
+    .base = { &mp_type_module },
+    .globals = (mp_obj_dict_t*)&runstatectl_module_globals,
+};
+
+MP_REGISTER_MODULE(MP_QSTR_runstatectl_native, runstatectl_native_user_cmodule);

--- a/mpymod/serialctl/init.py
+++ b/mpymod/serialctl/init.py
@@ -1,0 +1,15 @@
+print("serialctl module loaded")
+from env import env
+import serialctl_native as _native
+
+write = _native.write
+write_hex = _native.write_hex
+write_dec = _native.write_dec
+raw_write = _native.raw_write
+
+env['serial'] = {
+    'write': write,
+    'write_hex': write_hex,
+    'write_dec': write_dec,
+    'raw_write': raw_write,
+}

--- a/mpymod/serialctl/manifest.json
+++ b/mpymod/serialctl/manifest.json
@@ -1,0 +1,4 @@
+{
+  "mpy_entry": "init.py",
+  "mpy_import_as": "serialctl"
+}

--- a/mpymod/serialctl/native/serialctl.c
+++ b/mpymod/serialctl/native/serialctl.c
@@ -1,0 +1,51 @@
+#include "py/runtime.h"
+#include "serial.h"
+
+STATIC mp_obj_t serialctl_write(mp_obj_t text_obj) {
+    mp_uint_t len;
+    const char *data = mp_obj_str_get_data(text_obj, &len);
+    for (mp_uint_t i = 0; i < len; ++i) {
+        serial_putc(data[i]);
+    }
+    return mp_obj_new_int(len);
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(serialctl_write_obj, serialctl_write);
+
+STATIC mp_obj_t serialctl_write_hex(mp_obj_t value_obj) {
+    uint64_t value = mp_obj_get_int_truncated(value_obj);
+    serial_uhex(value);
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(serialctl_write_hex_obj, serialctl_write_hex);
+
+STATIC mp_obj_t serialctl_write_dec(mp_obj_t value_obj) {
+    uint32_t value = (uint32_t)mp_obj_get_int(value_obj);
+    serial_udec(value);
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(serialctl_write_dec_obj, serialctl_write_dec);
+
+STATIC mp_obj_t serialctl_raw_write(mp_obj_t data_obj) {
+    mp_uint_t len;
+    const char *data = mp_obj_str_get_data(data_obj, &len);
+    for (mp_uint_t i = 0; i < len; ++i) {
+        serial_raw_putc(data[i]);
+    }
+    return mp_obj_new_int(len);
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(serialctl_raw_write_obj, serialctl_raw_write);
+
+STATIC const mp_rom_map_elem_t serialctl_module_globals_table[] = {
+    { MP_ROM_QSTR(MP_QSTR_write), MP_ROM_PTR(&serialctl_write_obj) },
+    { MP_ROM_QSTR(MP_QSTR_write_hex), MP_ROM_PTR(&serialctl_write_hex_obj) },
+    { MP_ROM_QSTR(MP_QSTR_write_dec), MP_ROM_PTR(&serialctl_write_dec_obj) },
+    { MP_ROM_QSTR(MP_QSTR_raw_write), MP_ROM_PTR(&serialctl_raw_write_obj) },
+};
+STATIC MP_DEFINE_CONST_DICT(serialctl_module_globals, serialctl_module_globals_table);
+
+const mp_obj_module_t serialctl_native_user_cmodule = {
+    .base = { &mp_type_module },
+    .globals = (mp_obj_dict_t*)&serialctl_module_globals,
+};
+
+MP_REGISTER_MODULE(MP_QSTR_serialctl_native, serialctl_native_user_cmodule);

--- a/mpymod/tscript/init.py
+++ b/mpymod/tscript/init.py
@@ -1,0 +1,17 @@
+print("tscript module loaded")
+from env import env
+import tscript_native as _native
+
+run = _native.run
+
+
+def run_lines(lines):
+    if not isinstance(lines, (list, tuple)):
+        raise TypeError('expected list or tuple of strings')
+    program = '\n'.join(str(line) for line in lines)
+    _native.run(program)
+
+env['tscript'] = {
+    'run': run,
+    'run_lines': run_lines,
+}

--- a/mpymod/tscript/manifest.json
+++ b/mpymod/tscript/manifest.json
@@ -1,0 +1,4 @@
+{
+  "mpy_entry": "init.py",
+  "mpy_import_as": "tscript"
+}

--- a/mpymod/tscript/native/tscript.c
+++ b/mpymod/tscript/native/tscript.c
@@ -1,0 +1,22 @@
+#include "py/runtime.h"
+#include "script.h"
+
+STATIC mp_obj_t tscript_run(mp_obj_t code_obj) {
+    mp_uint_t len;
+    const char *code = mp_obj_str_get_data(code_obj, &len);
+    run_script(code, len);
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(tscript_run_obj, tscript_run);
+
+STATIC const mp_rom_map_elem_t tscript_module_globals_table[] = {
+    { MP_ROM_QSTR(MP_QSTR_run), MP_ROM_PTR(&tscript_run_obj) },
+};
+STATIC MP_DEFINE_CONST_DICT(tscript_module_globals, tscript_module_globals_table);
+
+const mp_obj_module_t tscript_native_user_cmodule = {
+    .base = { &mp_type_module },
+    .globals = (mp_obj_dict_t*)&tscript_module_globals,
+};
+
+MP_REGISTER_MODULE(MP_QSTR_tscript_native, tscript_native_user_cmodule);


### PR DESCRIPTION
## Summary
- add ten MicroPython modules that expose console, serial, debug logging, memory, filesystem, run-state, hardware info, keyboard input, TinyScript, and module execution helpers to the shared env
- provide filesystem capacity and mount-status helpers for the new filesystem bridge module
- document the availability of the in-kernel MicroPython libraries in the release notes

## Testing
- python3 -m compileall mpymod

------
https://chatgpt.com/codex/tasks/task_e_68d5cba31ee48330ac76db19b50adf3d