### PR TITLE
Fix MicroPython consolectl module build failure

### DIFF
--- a/mpymod/consolectl/native/consolectl.c
+++ b/mpymod/consolectl/native/consolectl.c
@@ -1,6 +1,11 @@
 #include "py/runtime.h"
 #include "console.h"
 #include <string.h>
+#include <stdint.h>
+
+#ifndef STATIC
+#define STATIC static
+#endif
 
 STATIC mp_obj_t consolectl_write(mp_obj_t text_obj) {
     mp_uint_t len;


### PR DESCRIPTION
## Summary
- ensure the consolectl native module defines STATIC when the MicroPython headers do not and include stdint for uint8_t usage
- automatically add MP_QSTR identifiers found in native modules to the embed port qstr pool during the build

## Testing
- `make -C micropython/examples/embedding -f micropython_embed.mk USERMOD_DIR=examples/embedding/micropython_embed/usermod`


------
https://chatgpt.com/codex/tasks/task_e_68d758e2288c83309cc69e65ff7f4640