### PR TITLE
Fix MicroPython module loader memory usage

### DIFF
--- a/kernel/mpy_loader.c
+++ b/kernel/mpy_loader.c
@@ -15,15 +15,15 @@ void mpymod_load_all(void) {
             if (c == '\\' || c == '"' || c == '\n' || c == '\r')
                 esc_len++; /* extra backslash */
         }
-        size_t total = name_len * 2 + m->source_len + esc_len + 128;
+        size_t total = name_len * 2 + m->source_len + esc_len + 160;
         char *buf = mem_alloc(total);
         if (!buf)
             continue;
         char *p = buf;
         memcpy(p, "import env\n", 11); p += 11;
-        memcpy(p, "env._mpymod_data['", 18); p += 18;
+        memcpy(p, "env._mpymod_exec('", 18); p += 18;
         memcpy(p, m->name, name_len); p += name_len;
-        memcpy(p, "'] = \"", 6); p += 6;
+        memcpy(p, "', \"", 4); p += 4;
         for (size_t j = 0; j < m->source_len; ++j) {
             char c = m->source[j];
             if (c == '\n') {
@@ -37,9 +37,7 @@ void mpymod_load_all(void) {
                 *p++ = c;
             }
         }
-        memcpy(p, "\"\nenv.mpyrun('", 14); p += 14;
-        memcpy(p, m->name, name_len); p += name_len;
-        memcpy(p, "')\n", 3); p += 3;
+        memcpy(p, "\")\n", 3); p += 3;
         *p = '\0';
         serial_write("mpy:\n");
         serial_write(buf);


### PR DESCRIPTION
## Summary
- rework the MicroPython bootstrap stub to execute module sources without caching their strings and expose a `c.getmod()` helper
- enlarge the embedded MicroPython heap to 128 KiB so that the `process` module compiles without running out of memory
- adjust the module loader and `mp_store_module` helper to call the new `_mpymod_exec()` hook directly

## Testing
- tests/full_kernel_test.sh *(fails: build.sh run truncates the boot log before QEMU finishes)*
- printf '1\n' | ./build.sh
- timeout 25s qemu-system-x86_64 -cdrom exocore.iso -boot order=d -serial stdio -monitor none -no-reboot -display none

------
https://chatgpt.com/codex/tasks/task_e_68d7752ae1fc8330ab1164d58d764346