### PR TITLE
Ensure env env dictionary is initialized before MicroPython modules run

### DIFF
--- a/kernel/micropython.c
+++ b/kernel/micropython.c
@@ -62,6 +62,8 @@ void mp_runtime_init(void) {
         /* expose helper functions via Python stub */
         mp_embed_exec_str(
             "import sys, env, c, builtins\n"
+            "if not hasattr(env, 'env'):\n"
+            "    env.env = {}\n"
             "_mpymod_cache = {}\n"
             "def _mpymod_exec(name, src, args=None):\n"
             "    ns = {'env': env.env, 'mpyrun': mpyrun, 'c': c, '__name__': name}\n"


### PR DESCRIPTION
## Summary
- initialize the env.env dictionary in the MicroPython bootstrap stub when missing so module imports no longer raise AttributeError

## Testing
- ./build.sh

------
https://chatgpt.com/codex/tasks/task_e_68d7aca8c5748330a27e06d560108d63