### PR TITLE
Add MicroPython shell demo and management profile

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -442,6 +442,11 @@ if [ -d run/userland ]; then
     USER_MODULES+=( "$py" )
   done
 fi
+if [ -d init/kernel/mgmntshell ]; then
+  while IFS= read -r -d '' py; do
+    USER_MODULES+=( "${py#./}" )
+  done < <(find init/kernel/mgmntshell -maxdepth 1 -type f -name '*.py' -print0)
+fi
 
 # Build MicroPython objects for embedding
 MP_BUILD=mpbuild
@@ -524,9 +529,17 @@ done
 USER_MODULES_BN=()
 for m in "${USER_MODULES[@]}"; do
   [ -f "$m" ] || continue
-  bn=$(basename "$m")
-  cp "$m" isodir/boot/"$bn"
-  USER_MODULES_BN+=( "$bn" )
+  case "$m" in
+    init/kernel/mgmntshell/*)
+      dest="$m"
+      ;;
+    *)
+      dest=$(basename "$m")
+      ;;
+  esac
+  mkdir -p "isodir/boot/$(dirname "$dest")"
+  cp "$m" "isodir/boot/$dest"
+  USER_MODULES_BN+=( "$dest" )
 done
 
 # include init script if present

--- a/init/kernel/init.py
+++ b/init/kernel/init.py
@@ -1,10 +1,276 @@
-print("ExoCore init starting")
-print("MicroPython environment ready")
+#mpyexo
+"""Interactive MicroPython shell showcasing kernel capabilities.
+
+This init script boots straight into a tiny management shell that
+demonstrates the integrated MicroPython environment and the helpers
+exposed by the ExoCore kernel.  The shell intentionally keeps its
+dependencies simple so it can run on the raw interpreter that ships
+with the kernel (no precompiled bytecode required).
+"""
 
 try:
-    import vga
-    print("Testing VGA module...")
-    vga.enable(True)
-    print("VGA module call succeeded")
-except Exception as e:
-    print("VGA module test failed:", e)
+    from env import env, mpyrun
+except ImportError as exc:  # pragma: no cover - defensive fallback
+    print("env module unavailable:", exc)
+    raise SystemExit
+
+SHELL_PROMPT = "exo> "
+DEFAULT_MODULES = (
+    "consolectl",
+    "debugview",
+    "hwinfo",
+    "memstats",
+    "modrunner",
+    "runstatectl",
+    "serialctl",
+    "vga",
+)
+
+shell_state = {
+    "loaded": {},
+    "profile": None,
+    "profile_state": None,
+}
+
+
+def _profile_modules():
+    profile = env.get("shell")
+    if isinstance(profile, dict):
+        modules = profile.get("modules") or DEFAULT_MODULES
+        shell_state["profile"] = profile
+        return tuple(modules)
+    return DEFAULT_MODULES
+
+
+def _load_module(name):
+    try:
+        mod = mpyrun(name)
+    except Exception as exc:  # pragma: no cover - runtime diagnostics
+        print("[!] failed to load %s: %s" % (name, exc))
+        return None
+    if mod is None:
+        print("[!] module %s not available" % name)
+        return None
+    shell_state["loaded"][name] = mod
+    return mod
+
+
+def bootstrap():
+    print("ExoCore MicroPython shell starting…")
+    modules = _profile_modules()
+    if shell_state.get("profile"):
+        profile = shell_state["profile"]
+        profile_name = profile.get("profile", "custom")
+        print("Profile: %s" % profile_name)
+    else:
+        print("Profile: builtin")
+    print("Preloading modules: %s" % ", ".join(modules))
+    for name in modules:
+        _load_module(name)
+
+    profile = shell_state.get("profile")
+    if isinstance(profile, dict):
+        bootstrapper = profile.get("bootstrap")
+        if callable(bootstrapper):
+            try:
+                shell_state["profile_state"] = bootstrapper()
+            except Exception as exc:
+                print("[!] profile bootstrap failed: %s" % exc)
+
+
+def _describe_env_value(key, value):
+    if isinstance(value, dict):
+        return "dict(%s)" % ", ".join(sorted(value.keys()))
+    if callable(value):
+        return "callable"
+    return type(value).__name__
+
+
+def cmd_help(args):
+    print("Available commands:")
+    for name in sorted(COMMANDS.keys()):
+        print("  %-8s - %s" % (name, COMMANDS[name][1]))
+
+
+def cmd_modules(args):
+    if not shell_state["loaded"]:
+        print("No modules loaded yet; use 'load <name>'.")
+        return
+    for name in sorted(shell_state["loaded"].keys()):
+        mod = shell_state["loaded"][name]
+        attrs = [k for k in dir(mod) if not k.startswith("__")]
+        print("%s: %s" % (name, ", ".join(attrs) if attrs else "<no public symbols>"))
+
+
+def cmd_load(args):
+    if not args:
+        print("Usage: load <module>")
+        return
+    name = args[0]
+    if name in shell_state["loaded"]:
+        print("Module %s already loaded." % name)
+        return
+    if _load_module(name):
+        print("Module %s ready." % name)
+
+
+def cmd_env(args):
+    keys = sorted(env.keys())
+    if not keys:
+        print("env is empty")
+        return
+    for key in keys:
+        print("%s: %s" % (key, _describe_env_value(key, env[key])))
+
+
+def cmd_status(args):
+    memory = env.get("memory")
+    if isinstance(memory, dict) and "heap_free" in memory:
+        try:
+            heap = memory["heap_free"]()
+            print("Heap free: %s bytes" % heap)
+        except Exception as exc:
+            print("heap_free unavailable: %s" % exc)
+    else:
+        print("Memory module not loaded.")
+
+    runstate = env.get("runstate")
+    if isinstance(runstate, dict):
+        try:
+            print("Current program: %s" % runstate["current_program"]())
+        except Exception as exc:
+            print("current_program unavailable: %s" % exc)
+        try:
+            print("User app active: %s" % runstate["current_user_app"]())
+        except Exception as exc:
+            print("current_user_app unavailable: %s" % exc)
+        try:
+            print("Debug mode: %s" % runstate["is_debug_mode"]())
+        except Exception as exc:
+            print("is_debug_mode unavailable: %s" % exc)
+        try:
+            print("VGA output: %s" % runstate["is_vga_output"]())
+        except Exception as exc:
+            print("is_vga_output unavailable: %s" % exc)
+    else:
+        print("Runstate module not loaded.")
+
+    vga_enabled = env.get("vga_enabled")
+    if vga_enabled is not None:
+        print("VGA toggle cached: %s" % vga_enabled)
+
+
+def cmd_run(args):
+    if not args:
+        print("Usage: run <module>")
+        return
+    modules_env = env.get("modules")
+    if not isinstance(modules_env, dict) or "run" not in modules_env:
+        print("modrunner not available; load 'modrunner' first.")
+        return
+    target = args[0]
+    try:
+        result = modules_env["run"](target)
+        if result is not None:
+            print("Result: %s" % (result,))
+    except Exception as exc:
+        print("Execution failed: %s" % exc)
+
+
+def cmd_py(args):
+    if not args:
+        print("Usage: py <python expression>")
+        return
+    code = " ".join(args)
+    ns = {"env": env, "mpyrun": mpyrun, "loaded": shell_state["loaded"]}
+    try:
+        exec(code, ns, ns)
+    except Exception as exc:
+        print("Python error: %s" % exc)
+
+
+def cmd_profile(args):
+    profile = shell_state.get("profile")
+    if not isinstance(profile, dict):
+        print("No management profile active.")
+        return
+    print("Profile details:")
+    for key in sorted(profile.keys()):
+        if key == "bootstrap":
+            print("  bootstrap: <callable>")
+        else:
+            print("  %s: %s" % (key, profile[key]))
+    state = shell_state.get("profile_state")
+    if state is not None:
+        print("Profile state: %s" % state)
+
+
+def cmd_exit(args):
+    raise SystemExit
+
+
+COMMANDS = {
+    "help": (cmd_help, "show this help text"),
+    "modules": (cmd_modules, "list loaded MicroPython modules"),
+    "load": (cmd_load, "load a MicroPython module by name"),
+    "env": (cmd_env, "inspect the shared kernel environment"),
+    "status": (cmd_status, "display kernel run-state information"),
+    "run": (cmd_run, "execute a stored module via modrunner"),
+    "py": (cmd_py, "execute a one-line Python snippet"),
+    "profile": (cmd_profile, "show active management profile info"),
+    "exit": (cmd_exit, "leave the shell"),
+    "quit": (cmd_exit, "alias for exit"),
+}
+
+
+def dispatch(line):
+    parts = line.strip().split()
+    if not parts:
+        return
+    command = parts[0]
+    handler = COMMANDS.get(command)
+    if not handler:
+        print("Unknown command '%s'. Type 'help' for a list." % command)
+        return
+    func = handler[0]
+    try:
+        func(parts[1:])
+    except SystemExit:
+        raise
+    except Exception as exc:  # pragma: no cover - runtime diagnostics
+        print("[!] command failed: %s" % exc)
+
+
+def repl():
+    while True:
+        try:
+            line = input(SHELL_PROMPT)
+        except EOFError:
+            print("EOF")
+            break
+        except KeyboardInterrupt:
+            print("^C")
+            continue
+        if line.strip() in ("exit", "quit"):
+            break
+        try:
+            dispatch(line)
+        except SystemExit:
+            break
+
+
+def main():
+    bootstrap()
+    cmd_help(())
+    repl()
+    heap_free = "?"
+    memory = env.get("memory")
+    if isinstance(memory, dict) and "heap_free" in memory:
+        try:
+            heap_free = memory["heap_free"]()
+        except Exception:
+            heap_free = "?"
+    print("Exiting shell. Final heap free: %s" % heap_free)
+
+
+main()

--- a/init/kernel/mgmntshell/init.py
+++ b/init/kernel/mgmntshell/init.py
@@ -1,0 +1,50 @@
+#mpyexo
+"""Management shell profile for ExoCore.
+
+This module is packaged only with the management shell boot option.  It
+preloads a curated set of MicroPython helpers and exposes metadata used by
+``init/kernel/init.py`` to present a tailored experience.
+"""
+
+from env import env, mpyrun
+
+MANAGEMENT_MODULES = (
+    "consolectl",
+    "modrunner",
+    "memstats",
+    "runstatectl",
+    "serialctl",
+    "debugview",
+    "hwinfo",
+)
+
+
+def bootstrap():
+    loaded = {}
+    for name in MANAGEMENT_MODULES:
+        try:
+            mod = mpyrun(name)
+        except Exception as exc:  # pragma: no cover - runtime diagnostics
+            print("[mgmnt] failed to load %s: %s" % (name, exc))
+            continue
+        if mod is None:
+            print("[mgmnt] module %s unavailable" % name)
+            continue
+        loaded[name] = mod
+    env['shell_state'] = {
+        'loaded': tuple(sorted(loaded.keys())),
+        'last_boot': None,
+    }
+    return loaded
+
+
+def module_list():
+    return MANAGEMENT_MODULES
+
+
+env['shell'] = {
+    'profile': 'management',
+    'modules': MANAGEMENT_MODULES,
+    'bootstrap': bootstrap,
+    'module_list': module_list,
+}


### PR DESCRIPTION
## Summary
- replace the kernel init script with an interactive MicroPython shell that preloads core modules and offers inspection commands
- add a dedicated management-shell profile script that defines the modules and bootstrap logic for the management shell entry
- update the build to package management-shell scripts from init/kernel/mgmntshell while preserving their directory structure

## Testing
- ./build.sh

------
https://chatgpt.com/codex/tasks/task_e_68d8a1e6b7308330bab9ea62de5cfd22