### PR TITLE
Fix MicroPython shell profile loading and management boot modules

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -584,6 +584,9 @@ cat >> isodir/boot/grub/grub.cfg << EOF
 menuentry "ExoCore-Management-shell (alpha)" {
   multiboot /boot/kernel.bin userland
 EOF
+for mod in "${MODULES[@]}"; do
+  echo "  module /boot/$mod $mod" >> isodir/boot/grub/grub.cfg
+done
 for mod in "${USER_MODULES_BN[@]}"; do
   echo "  module /boot/$mod userland /boot/$mod" >> isodir/boot/grub/grub.cfg
 done


### PR DESCRIPTION
## Summary
- harden the MicroPython init shell to fall back when mapping objects lack a .get helper
- include the standard module set when generating the management-shell GRUB entry so init/kernel/init.py is present

## Testing
- python3 -m py_compile init/kernel/init.py

------
https://chatgpt.com/codex/tasks/task_e_68d8a698c2c08330b5695126b6ad269b