### PR TITLE
Replace non-ASCII ellipsis in init banner

### DIFF
--- a/init/kernel/init.py
+++ b/init/kernel/init.py
@@ -80,7 +80,7 @@ def _load_module(name):
 
 
 def bootstrap():
-    print("ExoCore MicroPython shell starting…")
+    print("ExoCore MicroPython shell starting...")
     modules = _profile_modules()
     profile = _safe_get(shell_state, "profile")
     if isinstance(profile, dict):


### PR DESCRIPTION
## Summary
- replace the Unicode ellipsis in the MicroPython shell bootstrap banner with ASCII dots to keep the init script ASCII-safe

## Testing
- ./build.sh
- python -m py_compile init/kernel/init.py

------
https://chatgpt.com/codex/tasks/task_e_68d8d846edf88330859dea891cfa8b77