### PR TITLE
Improve MicroPython fatal error diagnostics

### DIFF
--- a/include/micropython.h
+++ b/include/micropython.h
@@ -5,11 +5,11 @@
 
 void mp_runtime_init(void);
 void mp_runtime_deinit(void);
-void mp_runtime_exec(const char *code, size_t size);
+void mp_runtime_exec(const char *code, size_t size, const char *filename);
 void mp_runtime_exec_mpy(const uint8_t *buf, size_t size);
 
 // legacy single-shot helpers
-void run_micropython(const char *code, size_t size)
+void run_micropython(const char *code, size_t size, const char *filename)
     __attribute__((force_align_arg_pointer));
 void run_micropython_mpy(const uint8_t *buf, size_t size)
     __attribute__((force_align_arg_pointer));

--- a/kernel/mpy_loader.c
+++ b/kernel/mpy_loader.c
@@ -42,7 +42,7 @@ void mpymod_load_all(void) {
         serial_write("mpy:\n");
         serial_write(buf);
         serial_write("\n");
-        mp_runtime_exec(buf, p - buf);
+        mp_runtime_exec(buf, p - buf, m->name);
         mem_free(buf, total);
     }
 }


### PR DESCRIPTION
## Summary
- add a custom MicroPython exception reporter that prints the traceback location and triggers a panic with the offending file/line
- plumb module filenames through the runtime execution paths so MicroPython scripts, loaders, and init scripts report accurate sources

## Testing
- ./build.sh

------
https://chatgpt.com/codex/tasks/task_e_68d8f04745588330b6ca7fb946cb5f37