### PR TITLE
Fix MicroPython shell dispatch argument parsing

### DIFF
--- a/init/kernel/init.py
+++ b/init/kernel/init.py
@@ -261,7 +261,13 @@ def dispatch(line):
         return
     func = handler[0]
     try:
-        func(parts[1:])
+        args = []
+        index = 1
+        size = len(parts)
+        while index < size:
+            args.append(parts[index])
+            index += 1
+        func(args)
     except SystemExit:
         raise
     except Exception as exc:  # pragma: no cover - runtime diagnostics


### PR DESCRIPTION
## Summary
- avoid MicroPython syntax error by building command arguments without slicing

## Testing
- python3 -m compileall init/kernel/init.py

------
https://chatgpt.com/codex/tasks/task_e_68d8f721f43883308eacf2d018b9edd6