### PR TITLE
Support init.mpy in kernel, stop precompiling init.py, and fix fb_sleep_hz timing

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -922,11 +922,7 @@ if [ -f "$INIT_SCRIPT" ]; then
   mkdir -p isodir/boot/init/kernel
   copy_if_different "$INIT_SCRIPT" isodir/boot/init/kernel/init.py
   ISO_DEPS+=(isodir/boot/init/kernel/init.py)
-  INIT_MPY="init/kernel/init.mpy"
-  compile_mpy_file "$INIT_SCRIPT" "$INIT_MPY"
-  copy_if_different "$INIT_MPY" isodir/boot/init/kernel/init.mpy
-  MODULES+=( "init/kernel/init.mpy" )
-  ISO_DEPS+=(isodir/boot/init/kernel/init.mpy)
+  MODULES+=( "init/kernel/init.py" )
 elif [ -f "$INIT_ELF" ]; then
   mkdir -p isodir/boot/init/kernel
   copy_if_different "$INIT_ELF" isodir/boot/init/kernel/init.elf

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -472,6 +472,13 @@ void kernel_main(uint32_t magic, multiboot_info_t *mbi) {
             init_name = name;
             break;
         }
+        if (name && strstr(name, "init/kernel/init.mpy")) {
+            init_src = (const uint8_t*)(uintptr_t)mods[i].mod_start;
+            init_size = mods[i].mod_end - mods[i].mod_start;
+            init_elf = 0;
+            init_name = name;
+            break;
+        }
         if (name && strstr(name, "init/kernel/init.elf")) {
             init_src = (const uint8_t*)(uintptr_t)mods[i].mod_start;
             init_size = mods[i].mod_end - mods[i].mod_start;

--- a/mpymod/consolectl/init.py
+++ b/mpymod/consolectl/init.py
@@ -262,8 +262,9 @@ def fb_sleep_hz(hz):
             return
         sleeper = getattr(time, 'sleep', None)
         if callable(sleeper):
-            sleeper(max(1, delay_ms // 1000))
-            return
+            if delay_ms >= 1000:
+                sleeper(delay_ms // 1000)
+                return
     except Exception:
         pass
 


### PR DESCRIPTION
### Motivation
- Preserve source `init.py` in the ISO instead of always precompiling to `.mpy` and add kernel support for loading precompiled `init.mpy` when present.
- Avoid calling `time.sleep` with a zero-second/fractional argument for sub-second delays in the framebuffer sleep helper to ensure more accurate timing behavior.

### Description
- Changed `build.sh` to add `init/kernel/init.py` to the packaged `MODULES` and removed the automatic compilation and inclusion of `init/kernel/init.mpy` and related copy steps. 
- Updated `kernel/main.c` to detect and accept `init/kernel/init.mpy` as a valid non-ELF init module in addition to `init.py` and `init.elf` when scanning multiboot modules. 
- Modified `mpymod/consolectl/init.py::fb_sleep_hz` to only call `time.sleep` when the delay is at least one second and otherwise fall back to the busy-loop timing path for sub-second delays.

### Testing
- Ran the project build using `./build.sh` to produce the ISO and the build completed successfully. 
- Built the kernel (C compilation) and the kernel build completed successfully. 
- Performed a smoke integration run to ensure the init module is found and the framebuffer sleep path executes; no automated failures were observed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f73b3deb8c8330a934bf8c07ed409e)