### PR TITLE
Keep MicroPython boot modules as raw .py to fix boot SyntaxError

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -708,31 +708,7 @@ for asm in run/*.asm; do
   fi
 done
 
-# Compile MicroPython .py modules to .mpy for faster startup while keeping source files available
-MPY_CROSS="$MP_DIR/mpy-cross/build/mpy-cross"
-if [ ! -x "$MPY_CROSS" ]; then
-  make -C "$MP_DIR/mpy-cross"
-fi
-compile_mpy_file() {
-  local src="$1"
-  local out="$2"
-  if [ ! -f "$out" ] || [ "$src" -nt "$out" ]; then
-    echo "Compiling $src → $out"
-    "$MPY_CROSS" -o "$out" "$src"
-  fi
-}
-for py in run/*.py; do
-  [ -f "$py" ] || continue
-  compile_mpy_file "$py" "${py%.py}.mpy"
-done
-if [ -d run/userland ]; then
-  for py in run/userland/*.py; do
-    [ -f "$py" ] || continue
-    compile_mpy_file "$py" "${py%.py}.mpy"
-    USER_MODULES+=( "${py%.py}.mpy" )
-    USER_MODULES+=( "$py" )
-  done
-fi
+# Keep MicroPython modules as raw .py files (kernel loader expects source scripts).
 if [ -d init/kernel/mgmntshell ]; then
   while IFS= read -r -d '' py; do
     USER_MODULES+=( "${py#./}" )
@@ -885,17 +861,11 @@ ISO_DEPS=(isodir/boot/kernel.bin)
 
 # 11) Copy modules into ISO
 MODULES=()
-for m in run/*.{bin,elf,ts,py,mpy}; do
+for m in run/*.{bin,elf,ts,py}; do
   [ -f "$m" ] || continue
   bn=$(basename "$m")
   copy_if_different "$m" "isodir/boot/$bn"
   ISO_DEPS+=("isodir/boot/$bn")
-  if [[ "$bn" == *.py ]]; then
-    mpy_bn="${bn%.py}.mpy"
-    if [ -f "run/$mpy_bn" ]; then
-      continue
-    fi
-  fi
   MODULES+=( "$bn" )
 done
 USER_MODULES_BN=()


### PR DESCRIPTION
### Motivation
- The kernel loader expects source MicroPython scripts, but the build previously packaged compiled `.mpy` artifacts which can be treated as non-source and trigger `SyntaxError: invalid syntax` on boot. 
- Preserve raw `.py` sources in the ISO so boot-time scripts are parsed by the runtime as intended. 

### Description
- Removed the `.mpy` compilation step and related packaging logic from `build.sh` so MicroPython modules remain as raw `.py` sources. 
- Adjusted the ISO module copy glob to `run/*.{bin,elf,ts,py}` to exclude `.mpy` artifacts from the runtime image. 
- Removed the logic that skipped `.py` files when a `.mpy` counterpart existed and added a clarifying comment that the kernel loader requires source scripts. 

### Testing
- Ran a full build with `printf '1\n' | ./build.sh` which produced `exocore.iso` successfully (build completed). 
- Booted the generated ISO in QEMU via `qemu-system-x86_64 -cdrom exocore.iso -m 128M -boot order=d -serial stdio -monitor none -display none -no-reboot` and captured headless logs, which showed normal boot milestones and the welcome demo output. 
- Automated test results: build succeeded ✅, QEMU boot succeeded ✅, and captured logs show no `SyntaxError: invalid syntax` during boot.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f74ae2ecf08330b518d5a2e251969d)