### PR TITLE
Add deterministic MicroPython module load priority support

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -377,6 +377,7 @@ out_path = sys.argv[1]
 with open(out_path, 'w') as out:
     out.write('#include "mpy_loader.h"\n#include <stddef.h>\n\n')
     entries = []
+    ordered_mods = []
     for mod in sorted(os.listdir('mpymod')):
         mod_dir = os.path.join('mpymod', mod)
         if not os.path.isdir(mod_dir):
@@ -384,13 +385,23 @@ with open(out_path, 'w') as out:
         manifest = os.path.join(mod_dir, 'manifest.json')
         name = mod
         entry = 'init.py'
+        priority = 100
         if os.path.exists(manifest):
             data = json.load(open(manifest))
             name = data.get('mpy_import_as', name)
             entry = data.get('mpy_entry') or 'init.py'
+            try:
+                priority = int(data.get('priority', 100))
+            except (TypeError, ValueError):
+                priority = 100
         src_path = os.path.join(mod_dir, entry)
         if not os.path.exists(src_path):
             continue
+        ordered_mods.append((priority, mod, name, src_path))
+
+    ordered_mods.sort(key=lambda item: (item[0], item[1]))
+
+    for _, mod, name, src_path in ordered_mods:
         with open(src_path, 'rb') as f:
             data = f.read()
         var = mod.replace('-', '_')

--- a/docs/Module-Development-Guide.md
+++ b/docs/Module-Development-Guide.md
@@ -24,12 +24,14 @@ The module loader expects a JSON document with these keys:
 
 - `mpy_import_as`: the import name visible to MicroPython (`import <name>`).
 - `mpy_entry`: Python entry file to execute during load.
+- `priority` (optional): numeric load priority for deterministic module initialization order. Lower values load first; default is `100`.
 - `c_modules` (optional): list of native C modules to compile and expose.
 
 Guidelines:
 
 - Keep `mpy_import_as` aligned with the module folder intent.
 - Use `mpy_entry: "init.py"` when your bootstrap file is `init.py`.
+- Set `priority` when your module has startup ordering requirements relative to other modules.
 - If a module is native-first, `mpy_entry` may be empty and Python code can still exist for utility wrappers.
 - Ensure each `c_modules[].name` matches the symbol imported in Python.
 


### PR DESCRIPTION
### Motivation

- Module initialization order was effectively uncontrollable and could produce unpredictable startup sequencing for MicroPython `mpymod` modules during embedding.
- Allowing modules to request a numeric load priority in their `manifest.json` enables explicit, deterministic boot ordering for dependency-sensitive modules.

### Description

- Parse an optional `priority` field from `mpymod/*/manifest.json` during the `mpy_modules.c` generation step in `build.sh`, with a default of `100` when missing or invalid. 
- Collect modules into an `ordered_mods` list and sort by `(priority, module_folder)` so lower numeric values load first and ties are broken by folder name. 
- Preserve the existing embedding behavior by still emitting `static const unsigned char <mod>_src[]` and `mpymod_table` entries after sorting. 
- Document the new `priority` manifest field and guidance in `docs/Module-Development-Guide.md` including the default and when to use it.

### Testing

- Ran `./test.sh` which exercised the build pipeline and returned successfully (script chose to skip interactive QEMU run). — Success.
- Ran `printf '2\n1\n2\n' | ./test.sh` to force a non-interactive build path; the build completed and produced an ISO, with logs showing `Building ISO (...)` and `Writing to 'stdio:exocore.iso' completed successfully.` — Success.
- Attempted `./build.sh run nographic` which did not complete due to the interactive architecture selection prompt in this non-interactive environment, so a full QEMU boot-order verification remains to be run interactively. — Blocked/Pending.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f82ab291888330832eb66760cd2b99)