### PR TITLE
Improve welcome demo rendering performance

### DIFF
--- a/init/kernel/init.py
+++ b/init/kernel/init.py
@@ -178,17 +178,23 @@ def run_welcome_demo():
     ]
 
     frame = 0
+    fill_rect(surface, 0, 0, width, height, 10, 14, 25)
+    fill_rect(surface, title_box_x, title_box_y, title_box_w, title_box_h, 20, 30, 120)
+    fill_rect(surface, title_box_x + 2, title_box_y + 2, title_box_w - 4, title_box_h - 4, 30, 45, 170)
+    _draw_text_centered(surface, fill_rect, WELCOME_TEXT, (255, 255, 255), title_box_y, title_box_h)
+
     while FRAMES <= 0 or frame < FRAMES:
-        fill_rect(surface, 0, 0, width, height, 10, 14, 25)
+        fill_rect(surface, 0, 0, width, title_box_y, 10, 14, 25)
+        lower_y = title_box_y + title_box_h
+        fill_rect(surface, 0, lower_y, width, height - lower_y, 10, 14, 25)
+        fill_rect(surface, 0, title_box_y, title_box_x, title_box_h, 10, 14, 25)
+        right_x = title_box_x + title_box_w
+        fill_rect(surface, right_x, title_box_y, width - right_x, title_box_h, 10, 14, 25)
 
         dot = 0
         while dot < width:
             fill_rect(surface, dot, (frame + dot) % height, 1, 1, 25, 40, 70)
             dot += 8
-
-        fill_rect(surface, title_box_x, title_box_y, title_box_w, title_box_h, 20, 30, 120)
-        fill_rect(surface, title_box_x + 2, title_box_y + 2, title_box_w - 4, title_box_h - 4, 30, 45, 170)
-        _draw_text_centered(surface, fill_rect, WELCOME_TEXT, (255, 255, 255), title_box_y, title_box_h)
 
         for shape in shapes:
             _update_shape(shape, width, height, avoid_box)


### PR DESCRIPTION
### Motivation
- The boot welcome demo was redrawing the title box and glyph text every frame, causing excessive `fb_fill_rect` calls and slowing animation responsiveness.
- Reduce per-frame framebuffer workload by preserving static UI elements and only updating dynamic regions.

### Description
- Pre-render the title panel and centered welcome text once before entering the animation loop by calling the title `fill_rect` and `_draw_text_centered` prior to the loop.
- Replace the full-screen per-frame clear with targeted clears that repaint only the regions outside the title box (top, bottom, left, and right strips) so the title panel remains static.
- Keep animated elements (background dots and moving shapes) intact and update only those each frame to preserve the demo behavior while lowering hot-path cost.
- No public API changes; modifications are confined to `init/kernel/init.py` demo logic.

### Testing
- Ran `./test.sh` which completed its non-interactive flow successfully (exit 0).
- Built an ISO using `printf '2\n' | ./build.sh` which completed and produced the ISO with the build message `Done, use './build.sh run [nographic]' to build & boot` indicating a successful build.
- Attempted to run the image headless with `printf '2\n' | timeout 30s ./build.sh run nographic` which timed out during a long rebuild and did not reach post-boot logs.
- Ran `./test.sh --skip-install --yes-compile --no-qemu` which failed due to an interactive target-architecture prompt in this environment, so a full non-interactive compile path needs confirmation in CI or a machine with the toolchain preinstalled.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f92f62ae888330941e30b520487949)