### PR TITLE
Optimize framebuffer text present with dirty-cell updates

### DIFF
--- a/include/framebuffer.h
+++ b/include/framebuffer.h
@@ -19,6 +19,8 @@ uint32_t framebuffer_width(void);
 uint32_t framebuffer_height(void);
 void framebuffer_draw_cell(uint32_t col, uint32_t row, uint16_t cell);
 void framebuffer_present_text_grid(const uint16_t *cells, uint32_t cols, uint32_t rows);
+void framebuffer_present_text_grid_dirty(const uint16_t *curr, const uint16_t *prev,
+                                         uint32_t cols, uint32_t rows);
 int framebuffer_blit_rgb24(uint32_t x, uint32_t y, uint32_t width, uint32_t height,
                            const uint8_t *rgb24, uint32_t stride_bytes);
 int framebuffer_blit_rgb24_scaled(uint32_t x, uint32_t y, uint32_t width, uint32_t height,

--- a/kernel/framebuffer.c
+++ b/kernel/framebuffer.c
@@ -326,3 +326,73 @@ void framebuffer_present_text_grid(const uint16_t *cells, uint32_t cols, uint32_
         }
     }
 }
+
+void framebuffer_present_text_grid_dirty(const uint16_t *curr, const uint16_t *prev,
+                                         uint32_t cols, uint32_t rows) {
+    if (!fb.enabled || curr == 0 || prev == 0 || cols == 0 || rows == 0) {
+        return;
+    }
+    if ((cols * 8u) > fb.logical_width) {
+        cols = fb.logical_width / 8u;
+    }
+    if ((rows * 8u) > fb.logical_height) {
+        rows = fb.logical_height / 8u;
+    }
+
+    uint32_t src_width = cols * 8u;
+    uint32_t src_height = rows * 8u;
+    uint32_t scale_x = (src_width > 0) ? (fb.logical_width / src_width) : 1u;
+    uint32_t scale_y = (src_height > 0) ? (fb.logical_height / src_height) : 1u;
+    uint32_t scale = scale_x < scale_y ? scale_x : scale_y;
+    if (scale == 0) {
+        scale = 1;
+    }
+
+    uint32_t draw_width = src_width * scale;
+    uint32_t draw_height = src_height * scale;
+    uint32_t offset_x = (fb.logical_width - draw_width) / 2u;
+    uint32_t offset_y = (fb.logical_height - draw_height) / 2u;
+
+    for (uint32_t row = 0; row < rows; ++row) {
+        for (uint32_t col = 0; col < cols; ++col) {
+            uint32_t idx = row * cols + col;
+            uint16_t cell = curr[idx];
+            if (cell == prev[idx]) {
+                continue;
+            }
+            uint8_t ch = (uint8_t)(cell & 0xFF);
+            uint8_t attr = (uint8_t)((cell >> 8) & 0xFF);
+            uint8_t fg = attr & 0x0F;
+            uint8_t bg = (attr >> 4) & 0x0F;
+            if (fg > 15) {
+                fg = VGA_WHITE;
+            }
+            if (bg > 15) {
+                bg = VGA_BLACK;
+            }
+            if (ch < 32 || ch > 127) {
+                ch = '?';
+            }
+            const uint8_t *glyph = &font_petme128_8x8[(ch - 32) * 8];
+            uint32_t base_x = offset_x + (col * 8u * scale);
+            uint32_t base_y = offset_y + (row * 8u * scale);
+            uint32_t fg_color = fb.palette[fg];
+            uint32_t bg_color = fb.palette[bg];
+
+            for (uint32_t gy = 0; gy < 8; ++gy) {
+                uint8_t bits = glyph[gy];
+                for (uint32_t gx = 0; gx < 8; ++gx) {
+                    uint32_t mask = (uint32_t)(1u << (7u - gx));
+                    uint32_t color = (bits & mask) ? fg_color : bg_color;
+                    uint32_t px0 = base_x + (gx * scale);
+                    uint32_t py0 = base_y + (gy * scale);
+                    for (uint32_t sy = 0; sy < scale; ++sy) {
+                        for (uint32_t sx = 0; sx < scale; ++sx) {
+                            write_pixel(px0 + sx, py0 + sy, color);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/kernel/vga_draw.c
+++ b/kernel/vga_draw.c
@@ -7,8 +7,12 @@
 #include <stddef.h>
 
 static uint16_t back_buffer[VGA_DRAW_ROWS * VGA_DRAW_COLS];
+static uint16_t prev_buffer[VGA_DRAW_ROWS * VGA_DRAW_COLS];
 static int active = 0;
 static int initialised = 0;
+static int prev_valid = 0;
+static uint32_t prev_cols = 0;
+static uint32_t prev_rows = 0;
 static volatile uint64_t *front_buffer;
 
 static inline uint16_t pack_cell(char ch, uint8_t attr) {
@@ -37,8 +41,12 @@ static void fill_cells(uint16_t *dst, uint32_t count, uint16_t cell) {
 void vga_draw_init(void) {
     uint16_t clear_cell = pack_cell(' ', VGA_ATTR(VGA_WHITE, VGA_BLACK));
     fill_cells(back_buffer, VGA_DRAW_ROWS * VGA_DRAW_COLS, clear_cell);
+    fill_cells(prev_buffer, VGA_DRAW_ROWS * VGA_DRAW_COLS, clear_cell);
     active = 0;
     initialised = 1;
+    prev_valid = 0;
+    prev_cols = 0;
+    prev_rows = 0;
     if (!framebuffer_enabled()) {
         mem_vram_lock("vga_draw");
         front_buffer = (volatile uint64_t *)mem_vram_base();
@@ -163,7 +171,20 @@ void vga_draw_present(void) {
         return;
     }
     if (framebuffer_enabled()) {
-        framebuffer_present_text_grid(back_buffer, VGA_DRAW_COLS, VGA_DRAW_ROWS);
+        if (!prev_valid || prev_cols != VGA_DRAW_COLS || prev_rows != VGA_DRAW_ROWS) {
+            framebuffer_present_text_grid(back_buffer, VGA_DRAW_COLS, VGA_DRAW_ROWS);
+        } else {
+            framebuffer_present_text_grid_dirty(back_buffer, prev_buffer, VGA_DRAW_COLS, VGA_DRAW_ROWS);
+        }
+        const uint64_t *src = (const uint64_t *)back_buffer;
+        uint64_t *dst = (uint64_t *)prev_buffer;
+        size_t count = (VGA_DRAW_ROWS * VGA_DRAW_COLS) / 4;
+        for (size_t i = 0; i < count; ++i) {
+            dst[i] = src[i];
+        }
+        prev_valid = 1;
+        prev_cols = VGA_DRAW_COLS;
+        prev_rows = VGA_DRAW_ROWS;
         return;
     }
     volatile uint64_t *dest = front_buffer;


### PR DESCRIPTION
### Motivation
- Reduce expensive full-screen redraws when running in framebuffer text mode by detecting and updating only changed text cells.
- Preserve existing full present behavior for the first frame and when grid dimensions change to avoid visual/scale mismatches.
- Maintain API symmetry by adding a dirty-present entrypoint to the framebuffer subsystem for reuse elsewhere.

### Description
- Added API declaration `framebuffer_present_text_grid_dirty(const uint16_t *curr, const uint16_t *prev, uint32_t cols, uint32_t rows)` in `include/framebuffer.h`.
- Implemented `framebuffer_present_text_grid_dirty` in `kernel/framebuffer.c` to compare `curr[idx]` vs `prev[idx]` per `(row,col)` and redraw only changed cells while reusing the same scaling/centering logic as the full present.
- Added a second snapshot buffer `prev_buffer` plus `prev_valid`, `prev_cols`, and `prev_rows` state to `kernel/vga_draw.c` and initialized them in `vga_draw_init`.
- Updated `vga_draw_present` to call the full `framebuffer_present_text_grid` on the first frame or when dimensions differ, otherwise call `framebuffer_present_text_grid_dirty`, then copy `back_buffer` into `prev_buffer` to maintain the snapshot.

### Testing
- Ran `./test.sh` non-interactively, which executed but defaulted to skipping compile and QEMU due to the interactive prompts; the script ran without error but did not perform a full runtime verification.
- Ran `./build.sh`, which progressed through MicroPython embedding generation and make steps and reached the interactive target-selection prompt without reporting build errors prior to that prompt.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f990147938833088439156f02ef986)