### PR TITLE
Improve macOS compatibility in build and test scripts

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,6 +2,7 @@
 set -e
 
 APT_UPDATED=""
+BREW_UPDATED=""
 apt_install() {
   if ! command -v apt-get >/dev/null 2>&1; then
     echo "apt-get not available; install packages manually: $*" >&2
@@ -12,6 +13,38 @@ apt_install() {
     APT_UPDATED=1
   fi
   DEBIAN_FRONTEND=noninteractive apt-get install -y "$@"
+}
+
+brew_install() {
+  if ! command -v brew >/dev/null 2>&1; then
+    echo "Homebrew not available; install packages manually: $*" >&2
+    return 1
+  fi
+  if [ -z "$BREW_UPDATED" ]; then
+    brew update
+    BREW_UPDATED=1
+  fi
+  brew install "$@"
+}
+
+install_build_deps() {
+  local os
+  os="$(uname -s)"
+  case "$os" in
+    Linux)
+      apt_install build-essential nasm grub-pc-bin grub-common xorriso mtools
+      ;;
+    Darwin)
+      brew_install nasm xorriso mtools
+      if ! command -v x86_64-elf-gcc >/dev/null 2>&1; then
+        brew_install x86_64-elf-gcc
+      fi
+      ;;
+    *)
+      echo "Unsupported OS: $os. Install toolchain dependencies manually." >&2
+      return 1
+      ;;
+  esac
 }
 
 needs_rebuild() {
@@ -227,6 +260,12 @@ if $commit_build; then
 fi
 
 # Repository updates are managed via update.sh
+
+if [ "${1:-}" = "deps" ]; then
+  install_build_deps
+  echo "Dependency installation finished."
+  exit 0
+fi
 
 if [ "$1" = "clean" ]; then
     rm -f arch/x86/boot.o arch/x86/idt.o arch/x86/user.o \

--- a/test.sh
+++ b/test.sh
@@ -4,6 +4,7 @@ set -Eeuo pipefail
 HEADER="Welcome to EXOCORE-TEST-BUILD"
 LOG_FILE="test_build.log"
 APT_UPDATED=false
+BREW_UPDATED=false
 
 CHOICE_INSTALL=""
 CHOICE_COMPILE=""
@@ -17,6 +18,13 @@ PKGS=(
   xorriso
   mtools
   qemu-system-x86
+)
+
+BREW_PKGS=(
+  nasm
+  xorriso
+  mtools
+  qemu
 )
 
 die() {
@@ -89,30 +97,50 @@ progress_bar() {
 }
 
 install_packages() {
-  command -v apt-get >/dev/null 2>&1 || die "apt-get not found. This installer only supports Debian/Ubuntu."
-
   echo
   echo "Installing required software..."
   progress_bar 5
 
-  if [[ "$APT_UPDATED" == false ]]; then
-    run_as_root env DEBIAN_FRONTEND=noninteractive apt-get update -y
-    APT_UPDATED=true
-  fi
-
-  local missing=()
-
-  for pkg in "${PKGS[@]}"; do
-    if ! dpkg -s "$pkg" >/dev/null 2>&1; then
-      missing+=("$pkg")
+  if command -v apt-get >/dev/null 2>&1; then
+    if [[ "$APT_UPDATED" == false ]]; then
+      run_as_root env DEBIAN_FRONTEND=noninteractive apt-get update -y
+      APT_UPDATED=true
     fi
-  done
 
-  if [[ ${#missing[@]} -eq 0 ]]; then
-    echo "All required packages are already installed."
+    local missing=()
+    for pkg in "${PKGS[@]}"; do
+      if ! dpkg -s "$pkg" >/dev/null 2>&1; then
+        missing+=("$pkg")
+      fi
+    done
+
+    if [[ ${#missing[@]} -eq 0 ]]; then
+      echo "All required packages are already installed."
+    else
+      echo "Installing: ${missing[*]}"
+      run_as_root env DEBIAN_FRONTEND=noninteractive apt-get install -y "${missing[@]}"
+    fi
+  elif command -v brew >/dev/null 2>&1; then
+    if [[ "$BREW_UPDATED" == false ]]; then
+      brew update
+      BREW_UPDATED=true
+    fi
+
+    local missing=()
+    for pkg in "${BREW_PKGS[@]}"; do
+      if ! brew list --formula "$pkg" >/dev/null 2>&1; then
+        missing+=("$pkg")
+      fi
+    done
+
+    if [[ ${#missing[@]} -eq 0 ]]; then
+      echo "All required packages are already installed."
+    else
+      echo "Installing with brew: ${missing[*]}"
+      brew install "${missing[@]}"
+    fi
   else
-    echo "Installing: ${missing[*]}"
-    run_as_root env DEBIAN_FRONTEND=noninteractive apt-get install -y "${missing[@]}"
+    die "No supported package manager found. Install dependencies manually."
   fi
 
   progress_bar 100


### PR DESCRIPTION
### Motivation
- Provide cross-platform dependency bootstrap so the build/test workflow works on macOS as well as Debian/Ubuntu hosts.
- Allow non-interactive installation of toolchain prerequisites on Darwin via Homebrew to avoid hard failure when `apt-get` is absent.

### Description
- Added `BREW_UPDATED`, `brew_install`, and `install_build_deps` helpers to `build.sh` and wired a `./build.sh deps` entrypoint for platform-aware prerequisite installation.
- On macOS `install_build_deps` installs `nasm`, `xorriso`, `mtools` and `x86_64-elf-gcc` where needed, while preserving the existing `apt-get` flow for Linux.
- Updated `test.sh` to track `BREW_UPDATED`, introduce a `BREW_PKGS` list, and implement dual-path `install_packages` logic that detects and uses either `apt-get` or `brew` to install missing packages.
- No existing Debian/Ubuntu behavior was removed; the scripts now fall back to a manual-install message if neither package manager is available.

### Testing
- Ran `bash -n build.sh` and the syntax check succeeded without errors.
- Ran `bash -n test.sh` and the syntax check succeeded without errors.
- Executed `./test.sh --help` and confirmed the usage/help output is printed, indicating the updated argument parsing and startup paths work; this command completed successfully.
- Further testing recommended: validate `./build.sh deps` and full build/QEMU run on an actual macOS host to confirm Homebrew installs and the toolchain behave as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fab7d7d6d48330b6cc6f741c673827)