### PR TITLE
fix(build): make dependency auto-install work on macOS in build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -27,6 +27,35 @@ brew_install() {
   brew install "$@"
 }
 
+
+pkg_install() {
+  local os
+  os="$(uname -s)"
+  case "$os" in
+    Linux)
+      apt_install "$@"
+      ;;
+    Darwin)
+      local mapped=()
+      local pkg
+      for pkg in "$@"; do
+        case "$pkg" in
+          build-essential) mapped+=(gcc make) ;;
+          grub-pc-bin|grub-common) mapped+=(grub xorriso) ;;
+          qemu-system) mapped+=(qemu) ;;
+          binutils-x86-64-linux-gnu|gcc-x86-64-linux-gnu) mapped+=(x86_64-elf-gcc) ;;
+          *) mapped+=("$pkg") ;;
+        esac
+      done
+      brew_install "${mapped[@]}"
+      ;;
+    *)
+      echo "Unsupported OS: $os. Install packages manually: $*" >&2
+      return 1
+      ;;
+  esac
+}
+
 install_build_deps() {
   local os
   os="$(uname -s)"
@@ -484,8 +513,13 @@ case "$arch_choice" in
     LD=ld; ARCH_FLAG=-m64; LDARCH="elf_x86_64";
     QEMU=qemu-system-x86_64; FALLBACK_PKG="build-essential" ;;
   2)
-    CC=x86_64-linux-gnu-gcc; LD=x86_64-linux-gnu-ld; ARCH_FLAG=-m64; LDARCH="elf_x86_64";
-    QEMU=qemu-system-x86_64; FALLBACK_PKG="binutils-x86-64-linux-gnu gcc-x86-64-linux-gnu" ;;
+    if [ "$(uname -s)" = "Darwin" ]; then
+      CC=x86_64-elf-gcc; LD=x86_64-elf-ld; FALLBACK_PKG="binutils-x86-64-linux-gnu gcc-x86-64-linux-gnu"
+    else
+      CC=x86_64-linux-gnu-gcc; LD=x86_64-linux-gnu-ld; FALLBACK_PKG="binutils-x86-64-linux-gnu gcc-x86-64-linux-gnu"
+    fi
+    ARCH_FLAG=-m64; LDARCH="elf_x86_64";
+    QEMU=qemu-system-x86_64 ;;
   *) echo "Invalid choice, bro."; exit 1 ;;
 esac
 


### PR DESCRIPTION
### Motivation
- The build script failed on macOS with `pkg_install: command not found` and attempted to use Linux-only cross-toolchain names that do not exist on Darwin. 
- The change was intended to make automatic dependency installation and cross-toolchain selection portable between Linux and macOS so local builds on macOS no longer abort.

### Description
- Added a new `pkg_install` helper that dispatches to `apt_install` on Linux and `brew_install` on Darwin and returns an error for other OSes. 
- Implemented package-name mapping in `pkg_install` to translate Linux package names to Homebrew equivalents (e.g., `build-essential` → `gcc make`, grub packages → `grub xorriso`, `qemu-system` → `qemu`, and Linux cross-toolchain names → `x86_64-elf-gcc`).
- Updated architecture option `2` (x86_64) to select `x86_64-elf-gcc`/`x86_64-elf-ld` on macOS and preserve `x86_64-linux-gnu-*` selection on Linux.
- Kept existing Linux behavior unchanged and wired the new installer so calls to `pkg_install` no longer fail on macOS.

### Testing
- Ran `bash -n build.sh` to validate script syntax and it completed successfully. 
- Ran `./test.sh` which exited with status 0 and printed `Skipping compile.` indicating the test harness executed in this environment. 
- No QEMU boot/run was performed by the automated tests in this environment, so runtime boot verification remains to be executed separately. 
- Automated checks passed; changes are limited to `build.sh` and do not modify other build artifacts.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fad5ae300083308f818776c794e66f)