### PR TITLE
Fix macOS MicroPython embed header resolution and add compiled version banner

### DIFF
--- a/VERSION_LOG.txt
+++ b/VERSION_LOG.txt
@@ -1,0 +1,9 @@
+# Version Log
+
+## 2026-05-06
+- Version: 0.0.1
+- Build counter seed: 1 (auto-incremented by `build.sh` into `build.txt`)
+- Notes:
+  - Added compile-time kernel version header generation from `version.txt`.
+  - Boot banner now prints `Version: <version>` immediately after `ExoCore booted`.
+  - Added freestanding `include/string.h` shim to unblock MicroPython embed compilation with cross toolchains on macOS.

--- a/build.sh
+++ b/build.sh
@@ -267,6 +267,17 @@ if [ "$stored_major" != "$current_major" ]; then
 fi
 count=$((count + 1))
 printf "%s:%d" "$current_major" "$count" > "$COUNT_FILE"
+
+BUILD_VERSION=$(cat "$VERSION_FILE")
+cat > include/version.h <<EOF
+#ifndef VERSION_H
+#define VERSION_H
+
+#define EXOCORE_VERSION "${BUILD_VERSION}"
+
+#endif /* VERSION_H */
+EOF
+
 if [ -f "$PREF_FILE" ]; then
     CHOIICEV=$(cat "$PREF_FILE")
 fi

--- a/include/string.h
+++ b/include/string.h
@@ -1,0 +1,7 @@
+#ifndef EXOCORE_STRING_H
+#define EXOCORE_STRING_H
+
+#include <stddef.h>
+#include "memutils.h"
+
+#endif /* EXOCORE_STRING_H */

--- a/include/version.h
+++ b/include/version.h
@@ -1,0 +1,6 @@
+#ifndef VERSION_H
+#define VERSION_H
+
+#define EXOCORE_VERSION "0.0.1"
+
+#endif /* VERSION_H */

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -19,6 +19,7 @@
 #include "modexec.h"
 #include "syscall.h"
 #include "buildinfo.h"
+#include "version.h"
 #include "vga_draw.h"
 #include "framebuffer.h"
 #include <string.h>
@@ -219,6 +220,8 @@ void kernel_main(uint32_t magic, multiboot_info_t *mbi) {
     /* 2) Banner */
     serial_write("ExoCore booted\n");
     console_puts("ExoCore booted\n");
+    serial_write("Version: " EXOCORE_VERSION "\n");
+    console_puts("Version: " EXOCORE_VERSION "\n");
     if (debug_mode) {
         serial_write("Debug mode enabled\n");
         console_puts("Debug mode enabled\n");


### PR DESCRIPTION
### Motivation
- Building with the x86_64-elf toolchain on macOS failed during MicroPython embed compilation because `<string.h>` could not be found, blocking ISO/kernel builds.
- The build system lacked an explicit mechanism to embed the configured version string into the kernel binary at compile time for on-boot display.

### Description
- Added a freestanding shim `include/string.h` that forwards basic declarations to the kernel's `memutils.h` to satisfy `<string.h>` includes during freestanding MicroPython embed compilation.
- Updated `build.sh` to generate `include/version.h` from `version.txt` on each build so the kernel compiles with a consistent `EXOCORE_VERSION` macro.
- Modified `kernel/main.c` to print `Version: <EXOCORE_VERSION>` immediately after the existing `ExoCore booted` banner on both console and serial output.
- Added `VERSION_LOG.txt` documenting the version/build change and the macOS build fix.

### Testing
- Ran `printf '2\n' | ./build.sh` to build with the x86_64-elf selection, and the build completed including MicroPython embed object compilation and ISO generation (successful).
- Ran `test.sh --skip-install --no-compile --headless-qemu` (headless QEMU run) and confirmed the serial boot log contained `ExoCore booted` and `Version: 0.0.1`, indicating the compiled-in version banner was present (successful).
- Automated build/test commands used: `./build.sh` (with scripted architecture choice) and `./test.sh --skip-install --no-compile --headless-qemu`, both of which completed without failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fad82fab208330a16df8d21e0818b2)