### PR TITLE
fix(demo): load ExoDraw module name in welcome demo

### DIFF
--- a/init/kernel/init.py
+++ b/init/kernel/init.py
@@ -60,9 +60,9 @@ def log(message):
 
 
 def _load_console_api():
-    mod = mpyrun("consolectl")
+    mod = mpyrun("ExoDraw")
     if mod is None:
-        raise RuntimeError("consolectl module unavailable")
+        raise RuntimeError("ExoDraw module unavailable")
 
     console = _safe_get(env, "console")
     if not isinstance(console, dict):


### PR DESCRIPTION
### Motivation
- The welcome demo was importing the legacy `consolectl` name which caused module lookup failures when the console module is packaged/imported as `ExoDraw`, so the demo loader must match the active module name.

### Description
- Replaced `mpyrun("consolectl")` with `mpyrun("ExoDraw")` and updated the runtime error text from `"consolectl module unavailable"` to `"ExoDraw module unavailable"` in `init/kernel/init.py`.

### Testing
- Verified the modified file compiles with `python3 -m py_compile init/kernel/init.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc1406413c8330a95fd9833365e6ab)