### PR TITLE
Add freestanding assert.h for kernel and cross builds

### DIFF
--- a/include/assert.h
+++ b/include/assert.h
@@ -1,0 +1,14 @@
+#ifndef EXOCORE_ASSERT_H
+#define EXOCORE_ASSERT_H
+
+/*
+ * Freestanding assert for kernel/cross builds.
+ * Provides the standard assert() interface without requiring host libc headers.
+ */
+#if defined(NDEBUG)
+#define assert(ignore) ((void)0)
+#else
+#define assert(expr) ((void)((expr) ? 0 : __builtin_trap()))
+#endif
+
+#endif /* EXOCORE_ASSERT_H */


### PR DESCRIPTION
### Motivation

- Provide a freestanding `assert` implementation usable in kernel/cross builds without host libc headers.

### Description

- Add `include/assert.h` that defines `assert(expr)` to call `__builtin_trap()` when assertions are enabled and to a no-op when `NDEBUG` is defined.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc11354ee4833090aa9f2f84234987)