### PR TITLE
Add freestanding assert, portable force-align macro, and MicroPython toolchain stamp

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -827,6 +827,16 @@ fi
 MP_BUILD=mpbuild
 mkdir -p "$MP_BUILD"
 MP_SRC="$MP_DIR/examples/embedding/micropython_embed"
+MP_TOOLCHAIN_STAMP="$MP_BUILD/.toolchain-stamp"
+MP_TOOLCHAIN_ID="$CC|$ARCH_FLAG|$LDARCH|$(uname -s)|$(uname -m)"
+if [ -f "$MP_TOOLCHAIN_STAMP" ]; then
+  prev_toolchain_id=$(cat "$MP_TOOLCHAIN_STAMP")
+  if [ "$prev_toolchain_id" != "$MP_TOOLCHAIN_ID" ]; then
+    echo "MicroPython toolchain changed; forcing rebuild of MicroPython objects"
+    rm -f "$MP_BUILD"/*.o "$MP_BUILD"/*.d kernel/micropython.o kernel/micropython.d
+  fi
+fi
+printf "%s" "$MP_TOOLCHAIN_ID" > "$MP_TOOLCHAIN_STAMP"
 MP_OBJS=()
 while IFS= read -r -d '' src; do
   obj="$MP_BUILD/$(echo ${src#$MP_SRC/} | tr '/-' '__' | sed 's/\.c$/.o/')"

--- a/include/assert.h
+++ b/include/assert.h
@@ -1,0 +1,14 @@
+#ifndef EXOCORE_ASSERT_H
+#define EXOCORE_ASSERT_H
+
+/*
+ * Freestanding assert for kernel/cross builds.
+ * Provides the standard assert() interface without requiring host libc headers.
+ */
+#if defined(NDEBUG)
+#define assert(ignore) ((void)0)
+#else
+#define assert(expr) ((void)((expr) ? 0 : __builtin_trap()))
+#endif
+
+#endif /* EXOCORE_ASSERT_H */

--- a/include/micropython.h
+++ b/include/micropython.h
@@ -3,6 +3,12 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#if defined(__GNUC__) && (defined(__i386__) || defined(__x86_64__))
+#define EXO_FORCE_ALIGN_ARG_POINTER __attribute__((force_align_arg_pointer))
+#else
+#define EXO_FORCE_ALIGN_ARG_POINTER
+#endif
+
 void mp_runtime_init(void);
 void mp_runtime_deinit(void);
 void mp_runtime_exec(const char *code, size_t size, const char *filename);
@@ -10,8 +16,8 @@ void mp_runtime_exec_mpy(const uint8_t *buf, size_t size);
 
 // legacy single-shot helpers
 void run_micropython(const char *code, size_t size, const char *filename)
-    __attribute__((force_align_arg_pointer));
+    EXO_FORCE_ALIGN_ARG_POINTER;
 void run_micropython_mpy(const uint8_t *buf, size_t size)
-    __attribute__((force_align_arg_pointer));
+    EXO_FORCE_ALIGN_ARG_POINTER;
 
 #endif

--- a/kernel/micropython.c
+++ b/kernel/micropython.c
@@ -217,14 +217,14 @@ void mp_runtime_exec_mpy(const uint8_t *buf, size_t size) {
     mp_embed_exec_mpy(buf, size);
 }
 
-__attribute__((force_align_arg_pointer))
+EXO_FORCE_ALIGN_ARG_POINTER
 void run_micropython(const char *code, size_t size, const char *filename) {
     mp_runtime_init();
     mp_runtime_exec(code, size, filename);
     mp_runtime_deinit();
 }
 
-__attribute__((force_align_arg_pointer))
+EXO_FORCE_ALIGN_ARG_POINTER
 void run_micropython_mpy(const uint8_t *buf, size_t size) {
     mp_runtime_init();
     mp_runtime_exec_mpy(buf, size);


### PR DESCRIPTION
### Motivation
- Provide a small freestanding `assert` for kernel/cross builds so code can use `assert()` without host libc.
- Make the `force_align_arg_pointer` attribute conditional and portable across architectures to avoid applying it where unsupported.
- Ensure MicroPython object files are rebuilt when the C toolchain or target architecture changes to avoid ABI/ABI-like mismatches.

### Description
- Add `include/assert.h` implementing a freestanding `assert()` that maps to `__builtin_trap()` when not optimized out by `NDEBUG`.
- Introduce `EXO_FORCE_ALIGN_ARG_POINTER` in `include/micropython.h` which expands to `__attribute__((force_align_arg_pointer))` only for GNU/x86 targets and is a no-op elsewhere.
- Replace direct `__attribute__((force_align_arg_pointer))` uses in `include/micropython.h` and `kernel/micropython.c` with `EXO_FORCE_ALIGN_ARG_POINTER` to make the annotation portable.
- Update `build.sh` to add a MicroPython toolchain stamp (`$MP_BUILD/.toolchain-stamp`) and an identifier built from `CC`, `ARCH_FLAG`, `LDARCH`, `uname -s`, and `uname -m`; when the stamp changes the script removes MicroPython object files to force a rebuild.

### Testing
- Ran the build script `./build.sh` on Linux x86_64 and completed a full kernel build successfully with the new changes.
- Verified that MicroPython object compilation occurs and that changing the toolchain identifier (e.g. `CC`/`ARCH_FLAG`) causes the stamp logic to remove MicroPython objects and trigger a rebuild.
- Confirmed there are no new compile errors after replacing attribute usage with `EXO_FORCE_ALIGN_ARG_POINTER` during the kernel build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc11354ee4833090aa9f2f84234987)